### PR TITLE
Auto-reload config when mdbase.yaml is modified externally

### DIFF
--- a/main.js
+++ b/main.js
@@ -3994,6 +3994,13 @@ var MdbasePlugin = class extends import_obsidian4.Plugin {
         }
       })
     );
+    this.registerEvent(
+      this.app.vault.on("modify", (file) => {
+        if (file.path === CONFIG_FILENAME) {
+          this.reload();
+        }
+      })
+    );
   }
   async initializeCollection() {
     this.config = await createDefaultConfig(this.app.vault);

--- a/src/collection/config.ts
+++ b/src/collection/config.ts
@@ -3,7 +3,7 @@ import { parseYaml, stringifyYaml } from "obsidian";
 import type { MdbaseConfig } from "../types.ts";
 import { SPEC_VERSION } from "../types.ts";
 
-const CONFIG_FILENAME = "mdbase.yaml";
+export const CONFIG_FILENAME = "mdbase.yaml";
 
 export async function loadConfig(vault: Vault): Promise<MdbaseConfig | null> {
   const file = vault.getFileByPath(CONFIG_FILENAME);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { App, Modal, Notice, Plugin, TFile } from "obsidian";
 import type { MdbaseConfig, TypeDefinition, ValidationIssue } from "./types.ts";
-import { createDefaultConfig, loadConfig } from "./collection/config.ts";
+import { CONFIG_FILENAME, createDefaultConfig, loadConfig } from "./collection/config.ts";
 import { loadTypes } from "./collection/typeLoader.ts";
 import { matchFileToTypes } from "./matching/matcher.ts";
 import { validateFile } from "./validation/validator.ts";
@@ -47,6 +47,14 @@ export default class MdbasePlugin extends Plugin {
       this.app.metadataCache.on("changed", (file) => {
         if (file.extension === "md") {
           this.validateAndDisplay(file);
+        }
+      })
+    );
+
+    this.registerEvent(
+      this.app.vault.on("modify", (file) => {
+        if (file.path === CONFIG_FILENAME) {
+          this.reload();
         }
       })
     );


### PR DESCRIPTION
## Summary

- Exports `CONFIG_FILENAME` from `src/collection/config.ts` so it can be referenced from the plugin entry point
- Registers a `vault.on("modify")` listener in `onload()` that calls the existing `reload()` method whenever `mdbase.yaml` changes
- Covers both in-Obsidian edits and external file system changes (e.g. editing in a text editor, synced via iCloud/Obsidian Sync)

## Test plan

- [ ] Edit `mdbase.yaml` directly in Obsidian — config reloads without a plugin restart
- [ ] Edit `mdbase.yaml` in an external editor while Obsidian is open — config reloads automatically
- [ ] Verify active file re-validates after reload (status bar updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)