### PR TITLE
Add prettier, husky, and lint-staged for code formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,18 @@ on:
   pull_request:
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm format:check
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+export VOLTA_HOME="${VOLTA_HOME:-$HOME/.volta}"
+export PATH="$VOLTA_HOME/bin:$PATH"
+node_modules/.bin/lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,1 @@
-export VOLTA_HOME="${VOLTA_HOME:-$HOME/.volta}"
-export PATH="$VOLTA_HOME/bin:$PATH"
 pnpm exec lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 export VOLTA_HOME="${VOLTA_HOME:-$HOME/.volta}"
 export PATH="$VOLTA_HOME/bin:$PATH"
-node_modules/.bin/lint-staged
+pnpm exec lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+main.js
+test-vault/
+node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2
+}

--- a/main.js
+++ b/main.js
@@ -3227,7 +3227,12 @@ var ISO_DATETIME = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{
 function validateFieldValue(value, def) {
   if (value === null || value === void 0) {
     if (def.required) {
-      return { valid: false, message: "Field is required", expected: def.type, actual: "null" };
+      return {
+        valid: false,
+        message: "Field is required",
+        expected: def.type,
+        actual: "null"
+      };
     }
     return { valid: true };
   }
@@ -3262,12 +3267,20 @@ function validateByType(value, def) {
     case "any":
       return { valid: true };
     default:
-      return { valid: false, message: `Unknown field type: ${String(def.type)}` };
+      return {
+        valid: false,
+        message: `Unknown field type: ${String(def.type)}`
+      };
   }
 }
 function validateString(value, def) {
   if (typeof value !== "string") {
-    return { valid: false, message: "Expected a string", expected: "string", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a string",
+      expected: "string",
+      actual: typeof value
+    };
   }
   if (def.min_length !== void 0 && value.length < def.min_length) {
     return {
@@ -3304,33 +3317,68 @@ function validateString(value, def) {
 function validateInteger(value, def) {
   const coerced = typeof value === "string" ? Number(value) : value;
   if (!Number.isInteger(coerced)) {
-    return { valid: false, message: "Expected an integer", expected: "integer", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected an integer",
+      expected: "integer",
+      actual: typeof value
+    };
   }
   const n = coerced;
   if (def.min !== void 0 && n < def.min) {
-    return { valid: false, message: `Value too small (min ${def.min})`, expected: `>= ${def.min}`, actual: String(n) };
+    return {
+      valid: false,
+      message: `Value too small (min ${def.min})`,
+      expected: `>= ${def.min}`,
+      actual: String(n)
+    };
   }
   if (def.max !== void 0 && n > def.max) {
-    return { valid: false, message: `Value too large (max ${def.max})`, expected: `<= ${def.max}`, actual: String(n) };
+    return {
+      valid: false,
+      message: `Value too large (max ${def.max})`,
+      expected: `<= ${def.max}`,
+      actual: String(n)
+    };
   }
   return { valid: true };
 }
 function validateNumber(value, def) {
   const coerced = typeof value === "string" ? Number(value) : value;
   if (typeof coerced !== "number" || isNaN(coerced)) {
-    return { valid: false, message: "Expected a number", expected: "number", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a number",
+      expected: "number",
+      actual: typeof value
+    };
   }
   if (def.min !== void 0 && coerced < def.min) {
-    return { valid: false, message: `Value too small (min ${def.min})`, expected: `>= ${def.min}`, actual: String(coerced) };
+    return {
+      valid: false,
+      message: `Value too small (min ${def.min})`,
+      expected: `>= ${def.min}`,
+      actual: String(coerced)
+    };
   }
   if (def.max !== void 0 && coerced > def.max) {
-    return { valid: false, message: `Value too large (max ${def.max})`, expected: `<= ${def.max}`, actual: String(coerced) };
+    return {
+      valid: false,
+      message: `Value too large (max ${def.max})`,
+      expected: `<= ${def.max}`,
+      actual: String(coerced)
+    };
   }
   return { valid: true };
 }
 function validateBoolean(value) {
   if (typeof value !== "boolean") {
-    return { valid: false, message: "Expected a boolean", expected: "boolean", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a boolean",
+      expected: "boolean",
+      actual: typeof value
+    };
   }
   return { valid: true };
 }
@@ -3384,13 +3432,24 @@ function validateEnum(value, def) {
 }
 function validateList(value, def) {
   if (!Array.isArray(value)) {
-    return { valid: false, message: "Expected a list", expected: "list", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a list",
+      expected: "list",
+      actual: typeof value
+    };
   }
   if (def.min_items !== void 0 && value.length < def.min_items) {
-    return { valid: false, message: `List too short (min ${def.min_items} items)` };
+    return {
+      valid: false,
+      message: `List too short (min ${def.min_items} items)`
+    };
   }
   if (def.max_items !== void 0 && value.length > def.max_items) {
-    return { valid: false, message: `List too long (max ${def.max_items} items)` };
+    return {
+      valid: false,
+      message: `List too long (max ${def.max_items} items)`
+    };
   }
   if (def.element_type && def.element_type !== "any") {
     for (let i = 0; i < value.length; i++) {
@@ -3416,7 +3475,12 @@ function validateList(value, def) {
 }
 function validateObject(value, def) {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return { valid: false, message: "Expected an object", expected: "object", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected an object",
+      expected: "object",
+      actual: typeof value
+    };
   }
   if (def.fields) {
     for (const [key, fieldDef] of Object.entries(def.fields)) {
@@ -3431,13 +3495,23 @@ function validateObject(value, def) {
 }
 function validateLink(value) {
   if (typeof value !== "string") {
-    return { valid: false, message: "Expected a link string", expected: "link", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a link string",
+      expected: "link",
+      actual: typeof value
+    };
   }
   return { valid: true };
 }
 function validateTags(value) {
   if (!Array.isArray(value)) {
-    return { valid: false, message: "Expected a list of tags", expected: "tags (list)", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a list of tags",
+      expected: "tags (list)",
+      actual: typeof value
+    };
   }
   for (let i = 0; i < value.length; i++) {
     if (typeof value[i] !== "string") {
@@ -3470,7 +3544,12 @@ function validateFile(filePath, frontmatter, matchedTypes, config) {
   if (matchedTypes.length === 0) return [];
   const issues = [];
   for (const typeDef of matchedTypes) {
-    const typeIssues = validateAgainstType(filePath, frontmatter, typeDef, config);
+    const typeIssues = validateAgainstType(
+      filePath,
+      frontmatter,
+      typeDef,
+      config
+    );
     issues.push(...typeIssues);
   }
   return issues;
@@ -3655,7 +3734,10 @@ var MdbaseSettingTab = class extends import_obsidian3.PluginSettingTab {
       meta.push(`fields_present: ${typeDef.match.fields_present.join(", ")}`);
     }
     if (typeDef.description) {
-      info.createDiv({ cls: "mdbase-type-item-meta", text: typeDef.description });
+      info.createDiv({
+        cls: "mdbase-type-item-meta",
+        text: typeDef.description
+      });
     }
     info.createDiv({ cls: "mdbase-type-item-meta", text: meta.join(" \xB7 ") });
     const actions = header.createDiv({ cls: "mdbase-type-item-actions" });
@@ -3687,7 +3769,9 @@ var TypeEditorModal = class extends import_obsidian3.Modal {
     this.draft = original ? structuredClone(original) : { name: "", fields: {} };
   }
   onOpen() {
-    this.titleEl.setText(this.original ? `Edit type: ${this.original.name}` : "Add type");
+    this.titleEl.setText(
+      this.original ? `Edit type: ${this.original.name}` : "Add type"
+    );
     this.render();
   }
   render() {
@@ -3717,7 +3801,9 @@ var TypeEditorModal = class extends import_obsidian3.Modal {
       }
     );
     new import_obsidian3.Setting(contentEl).setName("Strict mode").setDesc("How unknown fields are handled for this type.").addDropdown(
-      (d) => d.addOption("inherit", "Inherit from collection").addOption("false", "Allow").addOption("warn", "Warn").addOption("true", "Error").setValue(this.draft.strict === void 0 ? "inherit" : String(this.draft.strict)).onChange((v) => {
+      (d) => d.addOption("inherit", "Inherit from collection").addOption("false", "Allow").addOption("warn", "Warn").addOption("true", "Error").setValue(
+        this.draft.strict === void 0 ? "inherit" : String(this.draft.strict)
+      ).onChange((v) => {
         this.draft.strict = v === "inherit" ? void 0 : v === "true" ? true : v === "warn" ? "warn" : false;
       })
     );
@@ -3756,17 +3842,25 @@ var TypeEditorModal = class extends import_obsidian3.Modal {
       (btn) => btn.setButtonText("Add Field").onClick(() => {
         var _a, _b;
         (_b = (_a = this.draft).fields) != null ? _b : _a.fields = {};
-        const modal = new FieldEditorModal(this.app, null, null, (name, def) => {
-          this.draft.fields[name] = def;
-          this.render();
-        });
+        const modal = new FieldEditorModal(
+          this.app,
+          null,
+          null,
+          (name, def) => {
+            this.draft.fields[name] = def;
+            this.render();
+          }
+        );
         modal.open();
       })
     );
     const actions = contentEl.createDiv({ cls: "mdbase-actions-row" });
     const cancelBtn = actions.createEl("button", { text: "Cancel" });
     cancelBtn.addEventListener("click", () => this.close());
-    const saveBtn = actions.createEl("button", { text: "Save", cls: "mod-cta" });
+    const saveBtn = actions.createEl("button", {
+      text: "Save",
+      cls: "mod-cta"
+    });
     saveBtn.addEventListener("click", async () => {
       if (!this.draft.name) {
         new import_obsidian3.Notice("Type name is required.");
@@ -3794,15 +3888,24 @@ var TypeEditorModal = class extends import_obsidian3.Modal {
       const titleEl = header.createDiv();
       titleEl.createSpan({ cls: "mdbase-field-item-title", text: name });
       titleEl.createSpan({ cls: "mdbase-field-item-type", text: def.type });
-      if (def.required) titleEl.createSpan({ cls: "mdbase-field-item-required", text: "*required" });
+      if (def.required)
+        titleEl.createSpan({
+          cls: "mdbase-field-item-required",
+          text: "*required"
+        });
       const actions = header.createDiv({ cls: "mdbase-type-item-actions" });
       const editBtn = actions.createEl("button", { text: "Edit" });
       editBtn.addEventListener("click", () => {
-        const modal = new FieldEditorModal(this.app, name, def, (newName, newDef) => {
-          delete this.draft.fields[name];
-          this.draft.fields[newName] = newDef;
-          this.render();
-        });
+        const modal = new FieldEditorModal(
+          this.app,
+          name,
+          def,
+          (newName, newDef) => {
+            delete this.draft.fields[name];
+            this.draft.fields[newName] = newDef;
+            this.render();
+          }
+        );
         modal.open();
       });
       const delBtn = actions.createEl("button", { text: "Remove" });
@@ -3826,7 +3929,9 @@ var FieldEditorModal = class extends import_obsidian3.Modal {
     this.draft = originalDef ? structuredClone(originalDef) : { type: "string" };
   }
   onOpen() {
-    this.titleEl.setText(this.originalName ? `Edit field: ${this.originalName}` : "Add field");
+    this.titleEl.setText(
+      this.originalName ? `Edit field: ${this.originalName}` : "Add field"
+    );
     this.render();
   }
   render() {
@@ -3864,7 +3969,10 @@ var FieldEditorModal = class extends import_obsidian3.Modal {
     const actions = contentEl.createDiv({ cls: "mdbase-actions-row" });
     const cancelBtn = actions.createEl("button", { text: "Cancel" });
     cancelBtn.addEventListener("click", () => this.close());
-    const saveBtn = actions.createEl("button", { text: "Save field", cls: "mod-cta" });
+    const saveBtn = actions.createEl("button", {
+      text: "Save field",
+      cls: "mod-cta"
+    });
     saveBtn.addEventListener("click", () => {
       if (!this.draftName) {
         new import_obsidian3.Notice("Field name is required.");
@@ -3933,7 +4041,9 @@ var FieldEditorModal = class extends import_obsidian3.Modal {
     if (type === "list") {
       new import_obsidian3.Setting(el).setName("Element type").addDropdown((d) => {
         var _a;
-        const elementTypes = FIELD_TYPES.filter((f) => f !== "list" && f !== "object");
+        const elementTypes = FIELD_TYPES.filter(
+          (f) => f !== "list" && f !== "object"
+        );
         for (const ft of elementTypes) d.addOption(ft, ft);
         return d.setValue((_a = this.draft.element_type) != null ? _a : "string").onChange((v) => {
           this.draft.element_type = v;
@@ -4030,12 +4140,16 @@ var MdbasePlugin = class extends import_obsidian4.Plugin {
     const errors = fileIssues.filter((i) => i.severity === "error").length;
     const warnings = fileIssues.filter((i) => i.severity === "warning").length;
     if (errors > 0) {
-      this.statusBarItem.setText(`mdbase: ${errors} error${errors > 1 ? "s" : ""}`);
+      this.statusBarItem.setText(
+        `mdbase: ${errors} error${errors > 1 ? "s" : ""}`
+      );
       this.statusBarItem.addClass("mdbase-status-error");
       this.statusBarItem.removeClass("mdbase-status-warning");
       this.statusBarItem.removeClass("mdbase-status-ok");
     } else if (warnings > 0) {
-      this.statusBarItem.setText(`mdbase: ${warnings} warning${warnings > 1 ? "s" : ""}`);
+      this.statusBarItem.setText(
+        `mdbase: ${warnings} warning${warnings > 1 ? "s" : ""}`
+      );
       this.statusBarItem.addClass("mdbase-status-warning");
       this.statusBarItem.removeClass("mdbase-status-error");
       this.statusBarItem.removeClass("mdbase-status-ok");
@@ -4073,7 +4187,9 @@ var MdbasePlugin = class extends import_obsidian4.Plugin {
       const fileIssues = validateFile(file.path, fm, matched, this.config);
       this.issues.set(file.path, fileIssues);
       totalErrors += fileIssues.filter((i) => i.severity === "error").length;
-      totalWarnings += fileIssues.filter((i) => i.severity === "warning").length;
+      totalWarnings += fileIssues.filter(
+        (i) => i.severity === "warning"
+      ).length;
     }
     new import_obsidian4.Notice(
       `Validation complete: ${totalErrors} error${totalErrors !== 1 ? "s" : ""}, ${totalWarnings} warning${totalWarnings !== 1 ? "s" : ""} across ${files.length} files.`
@@ -4091,18 +4207,24 @@ var ValidationModal = class extends import_obsidian4.Modal {
     const { contentEl } = this;
     contentEl.addClass("mdbase-validation-modal");
     if (this.fileIssues.length === 0) {
-      contentEl.createEl("p", { text: "No issues found. \u2713", cls: "mdbase-status-ok" });
+      contentEl.createEl("p", {
+        text: "No issues found. \u2713",
+        cls: "mdbase-status-ok"
+      });
       return;
     }
     const list = contentEl.createDiv({ cls: "mdbase-issue-list" });
     for (const issue of this.fileIssues) {
-      const item = list.createDiv({ cls: `mdbase-issue-item ${issue.severity}` });
+      const item = list.createDiv({
+        cls: `mdbase-issue-item ${issue.severity}`
+      });
       item.createDiv({ cls: "mdbase-issue-field", text: issue.field });
       item.createDiv({ cls: "mdbase-issue-message", text: issue.message });
       const meta = [];
       if (issue.type) meta.push(`type: ${issue.type}`);
       if (issue.code) meta.push(issue.code);
-      if (meta.length) item.createDiv({ cls: "mdbase-issue-type", text: meta.join(" \xB7 ") });
+      if (meta.length)
+        item.createDiv({ cls: "mdbase-issue-type", text: meta.join(" \xB7 ") });
     }
   }
   onClose() {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,13 @@
     "test": "pnpm run test:output",
     "test:output": "pnpm run build && git diff --exit-code main.js"
   },
-  "packageManager": "pnpm@10.33.0",
   "keywords": [],
   "author": "alexlafroscia",
   "license": "MIT",
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "micromatch": "^4.0.7"
+  },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/micromatch": "^4.0.9",
@@ -23,8 +26,8 @@
     "tslib": "^2.6.3",
     "typescript": "^5.4.5"
   },
-  "dependencies": {
-    "js-yaml": "^4.1.0",
-    "micromatch": "^4.0.7"
+  "packageManager": "pnpm@10.33.0",
+  "volta": {
+    "node": "25.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
     "dev": "node esbuild.config.mjs",
     "build": "node esbuild.config.mjs production",
     "test": "pnpm run test:output",
-    "test:output": "pnpm run build && git diff --exit-code main.js"
+    "test:output": "pnpm run build && git diff --exit-code main.js",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,js,json,css,md,yaml,yml}": "prettier --write"
   },
   "keywords": [],
   "author": "alexlafroscia",
@@ -22,7 +28,10 @@
     "@types/node": "^22.0.0",
     "builtin-modules": "^4.0.0",
     "esbuild": "^0.21.5",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "obsidian": "^1.4.11",
+    "prettier": "^3.8.3",
     "tslib": "^2.6.3",
     "typescript": "^5.4.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,18 @@ importers:
       esbuild:
         specifier: ^0.21.5
         version: 0.21.5
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+      lint-staged:
+        specifier: ^16.4.0
+        version: 16.4.0
       obsidian:
         specifier: ^1.4.11
         version: 1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       tslib:
         specifier: ^2.6.3
         version: 2.8.1
@@ -307,6 +316,27 @@ packages:
         integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==,
       }
 
+  ansi-escapes@7.3.0:
+    resolution:
+      {
+        integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==,
+      }
+    engines: { node: ">=18" }
+
+  ansi-regex@6.2.2:
+    resolution:
+      {
+        integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
+      }
+    engines: { node: ">=12" }
+
+  ansi-styles@6.2.3:
+    resolution:
+      {
+        integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==,
+      }
+    engines: { node: ">=12" }
+
   argparse@2.0.1:
     resolution:
       {
@@ -327,11 +357,51 @@ packages:
       }
     engines: { node: ">=18.20" }
 
+  cli-cursor@5.0.0:
+    resolution:
+      {
+        integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==,
+      }
+    engines: { node: ">=18" }
+
+  cli-truncate@5.2.0:
+    resolution:
+      {
+        integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==,
+      }
+    engines: { node: ">=20" }
+
+  colorette@2.0.20:
+    resolution:
+      {
+        integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
+      }
+
+  commander@14.0.3:
+    resolution:
+      {
+        integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==,
+      }
+    engines: { node: ">=20" }
+
   crelt@1.0.6:
     resolution:
       {
         integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==,
       }
+
+  emoji-regex@10.6.0:
+    resolution:
+      {
+        integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==,
+      }
+
+  environment@1.1.0:
+    resolution:
+      {
+        integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==,
+      }
+    engines: { node: ">=18" }
 
   esbuild@0.21.5:
     resolution:
@@ -341,12 +411,40 @@ packages:
     engines: { node: ">=12" }
     hasBin: true
 
+  eventemitter3@5.0.4:
+    resolution:
+      {
+        integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
+      }
+
   fill-range@7.1.1:
     resolution:
       {
         integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
       }
     engines: { node: ">=8" }
+
+  get-east-asian-width@1.5.0:
+    resolution:
+      {
+        integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==,
+      }
+    engines: { node: ">=18" }
+
+  husky@9.1.7:
+    resolution:
+      {
+        integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
+  is-fullwidth-code-point@5.1.0:
+    resolution:
+      {
+        integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==,
+      }
+    engines: { node: ">=18" }
 
   is-number@7.0.0:
     resolution:
@@ -362,12 +460,41 @@ packages:
       }
     hasBin: true
 
+  lint-staged@16.4.0:
+    resolution:
+      {
+        integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==,
+      }
+    engines: { node: ">=20.17" }
+    hasBin: true
+
+  listr2@9.0.5:
+    resolution:
+      {
+        integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  log-update@6.1.0:
+    resolution:
+      {
+        integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==,
+      }
+    engines: { node: ">=18" }
+
   micromatch@4.0.8:
     resolution:
       {
         integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
       }
     engines: { node: ">=8.6" }
+
+  mimic-function@5.0.1:
+    resolution:
+      {
+        integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
+      }
+    engines: { node: ">=18" }
 
   moment@2.29.4:
     resolution:
@@ -384,6 +511,13 @@ packages:
       "@codemirror/state": 6.5.0
       "@codemirror/view": 6.38.6
 
+  onetime@7.0.0:
+    resolution:
+      {
+        integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==,
+      }
+    engines: { node: ">=18" }
+
   picomatch@2.3.2:
     resolution:
       {
@@ -391,11 +525,95 @@ packages:
       }
     engines: { node: ">=8.6" }
 
+  picomatch@4.0.4:
+    resolution:
+      {
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
+      }
+    engines: { node: ">=12" }
+
+  prettier@3.8.3:
+    resolution:
+      {
+        integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==,
+      }
+    engines: { node: ">=14" }
+    hasBin: true
+
+  restore-cursor@5.1.0:
+    resolution:
+      {
+        integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==,
+      }
+    engines: { node: ">=18" }
+
+  rfdc@1.4.1:
+    resolution:
+      {
+        integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
+      }
+
+  signal-exit@4.1.0:
+    resolution:
+      {
+        integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
+      }
+    engines: { node: ">=14" }
+
+  slice-ansi@7.1.2:
+    resolution:
+      {
+        integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==,
+      }
+    engines: { node: ">=18" }
+
+  slice-ansi@8.0.0:
+    resolution:
+      {
+        integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==,
+      }
+    engines: { node: ">=20" }
+
+  string-argv@0.3.2:
+    resolution:
+      {
+        integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==,
+      }
+    engines: { node: ">=0.6.19" }
+
+  string-width@7.2.0:
+    resolution:
+      {
+        integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==,
+      }
+    engines: { node: ">=18" }
+
+  string-width@8.2.0:
+    resolution:
+      {
+        integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==,
+      }
+    engines: { node: ">=20" }
+
+  strip-ansi@7.2.0:
+    resolution:
+      {
+        integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
+      }
+    engines: { node: ">=12" }
+
   style-mod@4.1.3:
     resolution:
       {
         integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==,
       }
+
+  tinyexec@1.1.1:
+    resolution:
+      {
+        integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==,
+      }
+    engines: { node: ">=18" }
 
   to-regex-range@5.0.1:
     resolution:
@@ -429,6 +647,21 @@ packages:
       {
         integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==,
       }
+
+  wrap-ansi@9.0.2:
+    resolution:
+      {
+        integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==,
+      }
+    engines: { node: ">=18" }
+
+  yaml@2.8.3:
+    resolution:
+      {
+        integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==,
+      }
+    engines: { node: ">= 14.6" }
+    hasBin: true
 
 snapshots:
   "@codemirror/state@6.5.0":
@@ -535,6 +768,14 @@ snapshots:
     dependencies:
       "@types/estree": 1.0.8
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
+
   argparse@2.0.1: {}
 
   braces@3.0.3:
@@ -543,7 +784,24 @@ snapshots:
 
   builtin-modules@4.0.0: {}
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.0
+
+  colorette@2.0.20: {}
+
+  commander@14.0.3: {}
+
   crelt@1.0.6: {}
+
+  emoji-regex@10.6.0: {}
+
+  environment@1.1.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -571,9 +829,19 @@ snapshots:
       "@esbuild/win32-ia32": 0.21.5
       "@esbuild/win32-x64": 0.21.5
 
+  eventemitter3@5.0.4: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  get-east-asian-width@1.5.0: {}
+
+  husky@9.1.7: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
 
   is-number@7.0.0: {}
 
@@ -581,10 +849,38 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  lint-staged@16.4.0:
+    dependencies:
+      commander: 14.0.3
+      listr2: 9.0.5
+      picomatch: 4.0.4
+      string-argv: 0.3.2
+      tinyexec: 1.1.1
+      yaml: 2.8.3
+
+  listr2@9.0.5:
+    dependencies:
+      cli-truncate: 5.2.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  mimic-function@5.0.1: {}
 
   moment@2.29.4: {}
 
@@ -595,9 +891,55 @@ snapshots:
       "@types/codemirror": 5.60.8
       moment: 2.29.4
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   picomatch@2.3.2: {}
 
+  picomatch@4.0.4: {}
+
+  prettier@3.8.3: {}
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  rfdc@1.4.1: {}
+
+  signal-exit@4.1.0: {}
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  string-argv@0.3.2: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   style-mod@4.1.3: {}
+
+  tinyexec@1.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -610,3 +952,11 @@ snapshots:
   undici-types@6.21.0: {}
 
   w3c-keyname@2.2.8: {}
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  yaml@2.8.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,11 +1,10 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     dependencies:
       js-yaml:
@@ -15,13 +14,13 @@ importers:
         specifier: ^4.0.7
         version: 4.0.8
     devDependencies:
-      '@types/js-yaml':
+      "@types/js-yaml":
         specifier: ^4.0.9
         version: 4.0.9
-      '@types/micromatch':
+      "@types/micromatch":
         specifier: ^4.0.9
         version: 4.0.10
-      '@types/node':
+      "@types/node":
         specifier: ^22.0.0
         version: 22.19.17
       builtin-modules:
@@ -41,349 +40,500 @@ importers:
         version: 5.9.3
 
 packages:
+  "@codemirror/state@6.5.0":
+    resolution:
+      {
+        integrity: sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==,
+      }
 
-  '@codemirror/state@6.5.0':
-    resolution: {integrity: sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==}
+  "@codemirror/view@6.38.6":
+    resolution:
+      {
+        integrity: sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==,
+      }
 
-  '@codemirror/view@6.38.6':
-    resolution: {integrity: sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==}
-
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
+  "@esbuild/aix-ppc64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
+  "@esbuild/android-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
+  "@esbuild/android-arm@0.21.5":
+    resolution:
+      {
+        integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
+  "@esbuild/android-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
+  "@esbuild/darwin-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
+  "@esbuild/darwin-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
+  "@esbuild/freebsd-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
+  "@esbuild/freebsd-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-arm@0.21.5":
+    resolution:
+      {
+        integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-ia32@0.21.5":
+    resolution:
+      {
+        integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==,
+      }
+    engines: { node: ">=12" }
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-loong64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==,
+      }
+    engines: { node: ">=12" }
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-mips64el@0.21.5":
+    resolution:
+      {
+        integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==,
+      }
+    engines: { node: ">=12" }
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-ppc64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==,
+      }
+    engines: { node: ">=12" }
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-riscv64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==,
+      }
+    engines: { node: ">=12" }
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-s390x@0.21.5":
+    resolution:
+      {
+        integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==,
+      }
+    engines: { node: ">=12" }
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
+  "@esbuild/netbsd-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
+  "@esbuild/openbsd-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
+  "@esbuild/sunos-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-arm64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-ia32@0.21.5":
+    resolution:
+      {
+        integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==,
+      }
+    engines: { node: ">=12" }
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-x64@0.21.5":
+    resolution:
+      {
+        integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [win32]
 
-  '@marijn/find-cluster-break@1.0.2':
-    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+  "@marijn/find-cluster-break@1.0.2":
+    resolution:
+      {
+        integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==,
+      }
 
-  '@types/braces@3.0.5':
-    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
+  "@types/braces@3.0.5":
+    resolution:
+      {
+        integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==,
+      }
 
-  '@types/codemirror@5.60.8':
-    resolution: {integrity: sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==}
+  "@types/codemirror@5.60.8":
+    resolution:
+      {
+        integrity: sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==,
+      }
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+  "@types/estree@1.0.8":
+    resolution:
+      {
+        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+      }
 
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+  "@types/js-yaml@4.0.9":
+    resolution:
+      {
+        integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==,
+      }
 
-  '@types/micromatch@4.0.10':
-    resolution: {integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==}
+  "@types/micromatch@4.0.10":
+    resolution:
+      {
+        integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==,
+      }
 
-  '@types/node@22.19.17':
-    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+  "@types/node@22.19.17":
+    resolution:
+      {
+        integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==,
+      }
 
-  '@types/tern@0.23.9':
-    resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
+  "@types/tern@0.23.9":
+    resolution:
+      {
+        integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==,
+      }
 
   argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    resolution:
+      {
+        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
+      }
 
   braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
+      }
+    engines: { node: ">=8" }
 
   builtin-modules@4.0.0:
-    resolution: {integrity: sha512-p1n8zyCkt1BVrKNFymOHjcDSAl7oq/gUvfgULv2EblgpPVQlQr9yHnWjg9IJ2MhfwPqiYqMMrr01OY7yQoK2yA==}
-    engines: {node: '>=18.20'}
+    resolution:
+      {
+        integrity: sha512-p1n8zyCkt1BVrKNFymOHjcDSAl7oq/gUvfgULv2EblgpPVQlQr9yHnWjg9IJ2MhfwPqiYqMMrr01OY7yQoK2yA==,
+      }
+    engines: { node: ">=18.20" }
 
   crelt@1.0.6:
-    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+    resolution:
+      {
+        integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==,
+      }
 
   esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==,
+      }
+    engines: { node: ">=12" }
     hasBin: true
 
   fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
+      }
+    engines: { node: ">=8" }
 
   is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
+    resolution:
+      {
+        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
+      }
+    engines: { node: ">=0.12.0" }
 
   js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    resolution:
+      {
+        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
+      }
     hasBin: true
 
   micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
+      }
+    engines: { node: ">=8.6" }
 
   moment@2.29.4:
-    resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
+    resolution:
+      {
+        integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==,
+      }
 
   obsidian@1.12.3:
-    resolution: {integrity: sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==}
+    resolution:
+      {
+        integrity: sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==,
+      }
     peerDependencies:
-      '@codemirror/state': 6.5.0
-      '@codemirror/view': 6.38.6
+      "@codemirror/state": 6.5.0
+      "@codemirror/view": 6.38.6
 
   picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
+      }
+    engines: { node: ">=8.6" }
 
   style-mod@4.1.3:
-    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+    resolution:
+      {
+        integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==,
+      }
 
   to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
+    resolution:
+      {
+        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
+      }
+    engines: { node: ">=8.0" }
 
   tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
 
   typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: ">=14.17" }
     hasBin: true
 
   undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+    resolution:
+      {
+        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
+      }
 
   w3c-keyname@2.2.8:
-    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+    resolution:
+      {
+        integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==,
+      }
 
 snapshots:
-
-  '@codemirror/state@6.5.0':
+  "@codemirror/state@6.5.0":
     dependencies:
-      '@marijn/find-cluster-break': 1.0.2
+      "@marijn/find-cluster-break": 1.0.2
 
-  '@codemirror/view@6.38.6':
+  "@codemirror/view@6.38.6":
     dependencies:
-      '@codemirror/state': 6.5.0
+      "@codemirror/state": 6.5.0
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
-  '@esbuild/aix-ppc64@0.21.5':
+  "@esbuild/aix-ppc64@0.21.5":
     optional: true
 
-  '@esbuild/android-arm64@0.21.5':
+  "@esbuild/android-arm64@0.21.5":
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
+  "@esbuild/android-arm@0.21.5":
     optional: true
 
-  '@esbuild/android-x64@0.21.5':
+  "@esbuild/android-x64@0.21.5":
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
+  "@esbuild/darwin-arm64@0.21.5":
     optional: true
 
-  '@esbuild/darwin-x64@0.21.5':
+  "@esbuild/darwin-x64@0.21.5":
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
+  "@esbuild/freebsd-arm64@0.21.5":
     optional: true
 
-  '@esbuild/freebsd-x64@0.21.5':
+  "@esbuild/freebsd-x64@0.21.5":
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
+  "@esbuild/linux-arm64@0.21.5":
     optional: true
 
-  '@esbuild/linux-arm@0.21.5':
+  "@esbuild/linux-arm@0.21.5":
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
+  "@esbuild/linux-ia32@0.21.5":
     optional: true
 
-  '@esbuild/linux-loong64@0.21.5':
+  "@esbuild/linux-loong64@0.21.5":
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
+  "@esbuild/linux-mips64el@0.21.5":
     optional: true
 
-  '@esbuild/linux-ppc64@0.21.5':
+  "@esbuild/linux-ppc64@0.21.5":
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
+  "@esbuild/linux-riscv64@0.21.5":
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
+  "@esbuild/linux-s390x@0.21.5":
     optional: true
 
-  '@esbuild/linux-x64@0.21.5':
+  "@esbuild/linux-x64@0.21.5":
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
+  "@esbuild/netbsd-x64@0.21.5":
     optional: true
 
-  '@esbuild/openbsd-x64@0.21.5':
+  "@esbuild/openbsd-x64@0.21.5":
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
+  "@esbuild/sunos-x64@0.21.5":
     optional: true
 
-  '@esbuild/win32-arm64@0.21.5':
+  "@esbuild/win32-arm64@0.21.5":
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
+  "@esbuild/win32-ia32@0.21.5":
     optional: true
 
-  '@esbuild/win32-x64@0.21.5':
+  "@esbuild/win32-x64@0.21.5":
     optional: true
 
-  '@marijn/find-cluster-break@1.0.2': {}
+  "@marijn/find-cluster-break@1.0.2": {}
 
-  '@types/braces@3.0.5': {}
+  "@types/braces@3.0.5": {}
 
-  '@types/codemirror@5.60.8':
+  "@types/codemirror@5.60.8":
     dependencies:
-      '@types/tern': 0.23.9
+      "@types/tern": 0.23.9
 
-  '@types/estree@1.0.8': {}
+  "@types/estree@1.0.8": {}
 
-  '@types/js-yaml@4.0.9': {}
+  "@types/js-yaml@4.0.9": {}
 
-  '@types/micromatch@4.0.10':
+  "@types/micromatch@4.0.10":
     dependencies:
-      '@types/braces': 3.0.5
+      "@types/braces": 3.0.5
 
-  '@types/node@22.19.17':
+  "@types/node@22.19.17":
     dependencies:
       undici-types: 6.21.0
 
-  '@types/tern@0.23.9':
+  "@types/tern@0.23.9":
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
 
   argparse@2.0.1: {}
 
@@ -397,29 +547,29 @@ snapshots:
 
   esbuild@0.21.5:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
+      "@esbuild/aix-ppc64": 0.21.5
+      "@esbuild/android-arm": 0.21.5
+      "@esbuild/android-arm64": 0.21.5
+      "@esbuild/android-x64": 0.21.5
+      "@esbuild/darwin-arm64": 0.21.5
+      "@esbuild/darwin-x64": 0.21.5
+      "@esbuild/freebsd-arm64": 0.21.5
+      "@esbuild/freebsd-x64": 0.21.5
+      "@esbuild/linux-arm": 0.21.5
+      "@esbuild/linux-arm64": 0.21.5
+      "@esbuild/linux-ia32": 0.21.5
+      "@esbuild/linux-loong64": 0.21.5
+      "@esbuild/linux-mips64el": 0.21.5
+      "@esbuild/linux-ppc64": 0.21.5
+      "@esbuild/linux-riscv64": 0.21.5
+      "@esbuild/linux-s390x": 0.21.5
+      "@esbuild/linux-x64": 0.21.5
+      "@esbuild/netbsd-x64": 0.21.5
+      "@esbuild/openbsd-x64": 0.21.5
+      "@esbuild/sunos-x64": 0.21.5
+      "@esbuild/win32-arm64": 0.21.5
+      "@esbuild/win32-ia32": 0.21.5
+      "@esbuild/win32-x64": 0.21.5
 
   fill-range@7.1.1:
     dependencies:
@@ -440,9 +590,9 @@ snapshots:
 
   obsidian@1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6):
     dependencies:
-      '@codemirror/state': 6.5.0
-      '@codemirror/view': 6.38.6
-      '@types/codemirror': 5.60.8
+      "@codemirror/state": 6.5.0
+      "@codemirror/view": 6.38.6
+      "@types/codemirror": 5.60.8
       moment: 2.29.4
 
   picomatch@2.3.2: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: false

--- a/src/collection/config.ts
+++ b/src/collection/config.ts
@@ -18,7 +18,10 @@ export async function loadConfig(vault: Vault): Promise<MdbaseConfig | null> {
   }
 }
 
-export async function saveConfig(vault: Vault, config: MdbaseConfig): Promise<void> {
+export async function saveConfig(
+  vault: Vault,
+  config: MdbaseConfig,
+): Promise<void> {
   const content = stringifyYaml(config as Record<string, unknown>);
   const file = vault.getFileByPath(CONFIG_FILENAME);
   if (file) {

--- a/src/collection/typeLoader.ts
+++ b/src/collection/typeLoader.ts
@@ -3,7 +3,10 @@ import { parseYaml, stringifyYaml } from "obsidian";
 import type { MdbaseConfig, TypeDefinition } from "../types.ts";
 import { getTypesFolder } from "../types.ts";
 
-function splitFrontmatter(content: string): { frontmatter: string; body: string } {
+function splitFrontmatter(content: string): {
+  frontmatter: string;
+  body: string;
+} {
   if (!content.startsWith("---")) {
     return { frontmatter: "", body: content };
   }
@@ -38,7 +41,7 @@ function serializeTypeFile(typeDef: TypeDefinition, body = ""): string {
 
 export async function loadTypes(
   vault: Vault,
-  config: MdbaseConfig
+  config: MdbaseConfig,
 ): Promise<Map<string, TypeDefinition>> {
   const types = new Map<string, TypeDefinition>();
   const folder = getTypesFolder(config);
@@ -65,7 +68,7 @@ export async function saveType(
   vault: Vault,
   config: MdbaseConfig,
   typeDef: TypeDefinition,
-  body = ""
+  body = "",
 ): Promise<void> {
   const folder = getTypesFolder(config);
   const filePath = `${folder}/${typeDef.name}.md`;
@@ -91,7 +94,7 @@ export async function saveType(
 export async function deleteType(
   vault: Vault,
   config: MdbaseConfig,
-  name: string
+  name: string,
 ): Promise<void> {
   const folder = getTypesFolder(config);
   const filePath = `${folder}/${name}.md`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ export default class MdbasePlugin extends Plugin {
         if (file instanceof TFile && file.extension === "md") {
           this.validateAndDisplay(file);
         }
-      })
+      }),
     );
 
     this.registerEvent(
@@ -48,7 +48,7 @@ export default class MdbasePlugin extends Plugin {
         if (file.extension === "md") {
           this.validateAndDisplay(file);
         }
-      })
+      }),
     );
   }
 
@@ -60,7 +60,9 @@ export default class MdbasePlugin extends Plugin {
 
   async reload(): Promise<void> {
     this.config = await loadConfig(this.app.vault);
-    this.types = this.config ? await loadTypes(this.app.vault, this.config) : new Map();
+    this.types = this.config
+      ? await loadTypes(this.app.vault, this.config)
+      : new Map();
     this.issues.clear();
     const activeFile = this.app.workspace.getActiveFile();
     if (activeFile) {
@@ -73,7 +75,8 @@ export default class MdbasePlugin extends Plugin {
       this.statusBarItem.setText("mdbase: no collection");
       return;
     }
-    const fm = (this.app.metadataCache.getFileCache(file)?.frontmatter ?? {}) as Record<string, unknown>;
+    const fm = (this.app.metadataCache.getFileCache(file)?.frontmatter ??
+      {}) as Record<string, unknown>;
     const matched = matchFileToTypes(file.path, fm, this.types, this.config);
     const fileIssues = validateFile(file.path, fm, matched, this.config);
     this.issues.set(file.path, fileIssues);
@@ -83,7 +86,7 @@ export default class MdbasePlugin extends Plugin {
   private updateStatusBar(
     file: TFile,
     fileIssues: ValidationIssue[],
-    hasType: boolean
+    hasType: boolean,
   ): void {
     if (!hasType) {
       this.statusBarItem.setText("mdbase: untyped");
@@ -93,12 +96,16 @@ export default class MdbasePlugin extends Plugin {
     const errors = fileIssues.filter((i) => i.severity === "error").length;
     const warnings = fileIssues.filter((i) => i.severity === "warning").length;
     if (errors > 0) {
-      this.statusBarItem.setText(`mdbase: ${errors} error${errors > 1 ? "s" : ""}`);
+      this.statusBarItem.setText(
+        `mdbase: ${errors} error${errors > 1 ? "s" : ""}`,
+      );
       this.statusBarItem.addClass("mdbase-status-error");
       this.statusBarItem.removeClass("mdbase-status-warning");
       this.statusBarItem.removeClass("mdbase-status-ok");
     } else if (warnings > 0) {
-      this.statusBarItem.setText(`mdbase: ${warnings} warning${warnings > 1 ? "s" : ""}`);
+      this.statusBarItem.setText(
+        `mdbase: ${warnings} warning${warnings > 1 ? "s" : ""}`,
+      );
       this.statusBarItem.addClass("mdbase-status-warning");
       this.statusBarItem.removeClass("mdbase-status-error");
       this.statusBarItem.removeClass("mdbase-status-ok");
@@ -132,16 +139,19 @@ export default class MdbasePlugin extends Plugin {
     this.issues.clear();
 
     for (const file of files) {
-      const fm = (this.app.metadataCache.getFileCache(file)?.frontmatter ?? {}) as Record<string, unknown>;
+      const fm = (this.app.metadataCache.getFileCache(file)?.frontmatter ??
+        {}) as Record<string, unknown>;
       const matched = matchFileToTypes(file.path, fm, this.types, this.config);
       const fileIssues = validateFile(file.path, fm, matched, this.config);
       this.issues.set(file.path, fileIssues);
       totalErrors += fileIssues.filter((i) => i.severity === "error").length;
-      totalWarnings += fileIssues.filter((i) => i.severity === "warning").length;
+      totalWarnings += fileIssues.filter(
+        (i) => i.severity === "warning",
+      ).length;
     }
 
     new Notice(
-      `Validation complete: ${totalErrors} error${totalErrors !== 1 ? "s" : ""}, ${totalWarnings} warning${totalWarnings !== 1 ? "s" : ""} across ${files.length} files.`
+      `Validation complete: ${totalErrors} error${totalErrors !== 1 ? "s" : ""}, ${totalWarnings} warning${totalWarnings !== 1 ? "s" : ""} across ${files.length} files.`,
     );
   }
 }
@@ -162,19 +172,25 @@ class ValidationModal extends Modal {
     contentEl.addClass("mdbase-validation-modal");
 
     if (this.fileIssues.length === 0) {
-      contentEl.createEl("p", { text: "No issues found. ✓", cls: "mdbase-status-ok" });
+      contentEl.createEl("p", {
+        text: "No issues found. ✓",
+        cls: "mdbase-status-ok",
+      });
       return;
     }
 
     const list = contentEl.createDiv({ cls: "mdbase-issue-list" });
     for (const issue of this.fileIssues) {
-      const item = list.createDiv({ cls: `mdbase-issue-item ${issue.severity}` });
+      const item = list.createDiv({
+        cls: `mdbase-issue-item ${issue.severity}`,
+      });
       item.createDiv({ cls: "mdbase-issue-field", text: issue.field });
       item.createDiv({ cls: "mdbase-issue-message", text: issue.message });
       const meta: string[] = [];
       if (issue.type) meta.push(`type: ${issue.type}`);
       if (issue.code) meta.push(issue.code);
-      if (meta.length) item.createDiv({ cls: "mdbase-issue-type", text: meta.join(" · ") });
+      if (meta.length)
+        item.createDiv({ cls: "mdbase-issue-type", text: meta.join(" · ") });
     }
   }
 

--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -5,7 +5,7 @@ import { getExplicitTypeKeys } from "../types.ts";
 function resolveInheritance(
   name: string,
   types: Map<string, TypeDefinition>,
-  visited = new Set<string>()
+  visited = new Set<string>(),
 ): TypeDefinition | null {
   if (visited.has(name)) return null; // circular
   visited.add(name);
@@ -25,7 +25,7 @@ function resolveInheritance(
 
 export function resolveType(
   name: string,
-  types: Map<string, TypeDefinition>
+  types: Map<string, TypeDefinition>,
 ): TypeDefinition | null {
   return resolveInheritance(name.toLowerCase(), types);
 }
@@ -34,7 +34,7 @@ export function matchFileToTypes(
   filePath: string,
   frontmatter: Record<string, unknown>,
   types: Map<string, TypeDefinition>,
-  config: MdbaseConfig
+  config: MdbaseConfig,
 ): TypeDefinition[] {
   const explicitKeys = getExplicitTypeKeys(config);
 
@@ -42,7 +42,9 @@ export function matchFileToTypes(
   for (const key of explicitKeys) {
     const val = frontmatter[key];
     if (val !== undefined && val !== null) {
-      const names: string[] = Array.isArray(val) ? val.map(String) : [String(val)];
+      const names: string[] = Array.isArray(val)
+        ? val.map(String)
+        : [String(val)];
       const resolved: TypeDefinition[] = [];
       for (const name of names) {
         const def = resolveType(name, types);
@@ -68,7 +70,7 @@ export function matchFileToTypes(
 function matchesRules(
   filePath: string,
   frontmatter: Record<string, unknown>,
-  typeDef: TypeDefinition
+  typeDef: TypeDefinition,
 ): boolean {
   const { match } = typeDef;
   if (!match) return false;

--- a/src/schema/fieldTypes.ts
+++ b/src/schema/fieldTypes.ts
@@ -15,11 +15,16 @@ const ISO_DATETIME =
 
 export function validateFieldValue(
   value: unknown,
-  def: FieldDef
+  def: FieldDef,
 ): FieldValidationResult {
   if (value === null || value === undefined) {
     if (def.required) {
-      return { valid: false, message: "Field is required", expected: def.type, actual: "null" };
+      return {
+        valid: false,
+        message: "Field is required",
+        expected: def.type,
+        actual: "null",
+      };
     }
     return { valid: true };
   }
@@ -28,27 +33,48 @@ export function validateFieldValue(
 
 function validateByType(value: unknown, def: FieldDef): FieldValidationResult {
   switch (def.type) {
-    case "string": return validateString(value, def);
-    case "integer": return validateInteger(value, def);
-    case "number": return validateNumber(value, def);
-    case "boolean": return validateBoolean(value);
-    case "date": return validateDate(value);
-    case "datetime": return validateDatetime(value);
-    case "time": return validateTime(value);
-    case "enum": return validateEnum(value, def);
-    case "list": return validateList(value, def);
-    case "object": return validateObject(value, def);
-    case "link": return validateLink(value);
-    case "tags": return validateTags(value);
-    case "any": return { valid: true };
+    case "string":
+      return validateString(value, def);
+    case "integer":
+      return validateInteger(value, def);
+    case "number":
+      return validateNumber(value, def);
+    case "boolean":
+      return validateBoolean(value);
+    case "date":
+      return validateDate(value);
+    case "datetime":
+      return validateDatetime(value);
+    case "time":
+      return validateTime(value);
+    case "enum":
+      return validateEnum(value, def);
+    case "list":
+      return validateList(value, def);
+    case "object":
+      return validateObject(value, def);
+    case "link":
+      return validateLink(value);
+    case "tags":
+      return validateTags(value);
+    case "any":
+      return { valid: true };
     default:
-      return { valid: false, message: `Unknown field type: ${String(def.type)}` };
+      return {
+        valid: false,
+        message: `Unknown field type: ${String(def.type)}`,
+      };
   }
 }
 
 function validateString(value: unknown, def: FieldDef): FieldValidationResult {
   if (typeof value !== "string") {
-    return { valid: false, message: "Expected a string", expected: "string", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a string",
+      expected: "string",
+      actual: typeof value,
+    };
   }
   if (def.min_length !== undefined && value.length < def.min_length) {
     return {
@@ -86,14 +112,29 @@ function validateString(value: unknown, def: FieldDef): FieldValidationResult {
 function validateInteger(value: unknown, def: FieldDef): FieldValidationResult {
   const coerced = typeof value === "string" ? Number(value) : value;
   if (!Number.isInteger(coerced)) {
-    return { valid: false, message: "Expected an integer", expected: "integer", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected an integer",
+      expected: "integer",
+      actual: typeof value,
+    };
   }
   const n = coerced as number;
   if (def.min !== undefined && n < def.min) {
-    return { valid: false, message: `Value too small (min ${def.min})`, expected: `>= ${def.min}`, actual: String(n) };
+    return {
+      valid: false,
+      message: `Value too small (min ${def.min})`,
+      expected: `>= ${def.min}`,
+      actual: String(n),
+    };
   }
   if (def.max !== undefined && n > def.max) {
-    return { valid: false, message: `Value too large (max ${def.max})`, expected: `<= ${def.max}`, actual: String(n) };
+    return {
+      valid: false,
+      message: `Value too large (max ${def.max})`,
+      expected: `<= ${def.max}`,
+      actual: String(n),
+    };
   }
   return { valid: true };
 }
@@ -101,20 +142,40 @@ function validateInteger(value: unknown, def: FieldDef): FieldValidationResult {
 function validateNumber(value: unknown, def: FieldDef): FieldValidationResult {
   const coerced = typeof value === "string" ? Number(value) : value;
   if (typeof coerced !== "number" || isNaN(coerced)) {
-    return { valid: false, message: "Expected a number", expected: "number", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a number",
+      expected: "number",
+      actual: typeof value,
+    };
   }
   if (def.min !== undefined && coerced < def.min) {
-    return { valid: false, message: `Value too small (min ${def.min})`, expected: `>= ${def.min}`, actual: String(coerced) };
+    return {
+      valid: false,
+      message: `Value too small (min ${def.min})`,
+      expected: `>= ${def.min}`,
+      actual: String(coerced),
+    };
   }
   if (def.max !== undefined && coerced > def.max) {
-    return { valid: false, message: `Value too large (max ${def.max})`, expected: `<= ${def.max}`, actual: String(coerced) };
+    return {
+      valid: false,
+      message: `Value too large (max ${def.max})`,
+      expected: `<= ${def.max}`,
+      actual: String(coerced),
+    };
   }
   return { valid: true };
 }
 
 function validateBoolean(value: unknown): FieldValidationResult {
   if (typeof value !== "boolean") {
-    return { valid: false, message: "Expected a boolean", expected: "boolean", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a boolean",
+      expected: "boolean",
+      actual: typeof value,
+    };
   }
   return { valid: true };
 }
@@ -132,7 +193,12 @@ function validateDate(value: unknown): FieldValidationResult {
 }
 
 function validateDatetime(value: unknown): FieldValidationResult {
-  const s = typeof value === "string" ? value : value instanceof Date ? value.toISOString() : null;
+  const s =
+    typeof value === "string"
+      ? value
+      : value instanceof Date
+        ? value.toISOString()
+        : null;
   if (!s || !ISO_DATETIME.test(s)) {
     return {
       valid: false,
@@ -173,13 +239,24 @@ function validateEnum(value: unknown, def: FieldDef): FieldValidationResult {
 
 function validateList(value: unknown, def: FieldDef): FieldValidationResult {
   if (!Array.isArray(value)) {
-    return { valid: false, message: "Expected a list", expected: "list", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a list",
+      expected: "list",
+      actual: typeof value,
+    };
   }
   if (def.min_items !== undefined && value.length < def.min_items) {
-    return { valid: false, message: `List too short (min ${def.min_items} items)` };
+    return {
+      valid: false,
+      message: `List too short (min ${def.min_items} items)`,
+    };
   }
   if (def.max_items !== undefined && value.length > def.max_items) {
-    return { valid: false, message: `List too long (max ${def.max_items} items)` };
+    return {
+      valid: false,
+      message: `List too long (max ${def.max_items} items)`,
+    };
   }
   if (def.element_type && def.element_type !== "any") {
     for (let i = 0; i < value.length; i++) {
@@ -206,7 +283,12 @@ function validateList(value: unknown, def: FieldDef): FieldValidationResult {
 
 function validateObject(value: unknown, def: FieldDef): FieldValidationResult {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return { valid: false, message: "Expected an object", expected: "object", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected an object",
+      expected: "object",
+      actual: typeof value,
+    };
   }
   if (def.fields) {
     for (const [key, fieldDef] of Object.entries(def.fields)) {
@@ -223,14 +305,24 @@ function validateObject(value: unknown, def: FieldDef): FieldValidationResult {
 function validateLink(value: unknown): FieldValidationResult {
   // Level 4 handles deep link resolution; here we just check it's a string
   if (typeof value !== "string") {
-    return { valid: false, message: "Expected a link string", expected: "link", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a link string",
+      expected: "link",
+      actual: typeof value,
+    };
   }
   return { valid: true };
 }
 
 function validateTags(value: unknown): FieldValidationResult {
   if (!Array.isArray(value)) {
-    return { valid: false, message: "Expected a list of tags", expected: "tags (list)", actual: typeof value };
+    return {
+      valid: false,
+      message: "Expected a list of tags",
+      expected: "tags (list)",
+      actual: typeof value,
+    };
   }
   for (let i = 0; i < value.length; i++) {
     if (typeof value[i] !== "string") {
@@ -241,6 +333,17 @@ function validateTags(value: unknown): FieldValidationResult {
 }
 
 export const FIELD_TYPES: FieldType[] = [
-  "string", "integer", "number", "boolean", "date", "datetime",
-  "time", "enum", "list", "object", "link", "tags", "any",
+  "string",
+  "integer",
+  "number",
+  "boolean",
+  "date",
+  "datetime",
+  "time",
+  "enum",
+  "list",
+  "object",
+  "link",
+  "tags",
+  "any",
 ];

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -1,6 +1,18 @@
-import { App, Modal, Notice, PluginSettingTab, Setting, setIcon } from "obsidian";
+import {
+  App,
+  Modal,
+  Notice,
+  PluginSettingTab,
+  Setting,
+  setIcon,
+} from "obsidian";
 import type MdbasePlugin from "../main.ts";
-import type { FieldDef, FieldType, MdbaseConfig, TypeDefinition } from "../types.ts";
+import type {
+  FieldDef,
+  FieldType,
+  MdbaseConfig,
+  TypeDefinition,
+} from "../types.ts";
 import { FIELD_TYPES } from "../schema/fieldTypes.ts";
 import { saveConfig } from "../collection/config.ts";
 import { deleteType, saveType } from "../collection/typeLoader.ts";
@@ -44,11 +56,14 @@ export class MdbaseSettingTab extends PluginSettingTab {
           .onClick(async () => {
             await this.plugin.initializeCollection();
             this.display();
-          })
+          }),
       );
   }
 
-  private renderCollectionSettings(el: HTMLElement, config: MdbaseConfig): void {
+  private renderCollectionSettings(
+    el: HTMLElement,
+    config: MdbaseConfig,
+  ): void {
     const section = el.createDiv({ cls: "mdbase-settings-section" });
     section.createEl("h3", { text: "Collection Settings" });
 
@@ -56,24 +71,20 @@ export class MdbaseSettingTab extends PluginSettingTab {
       .setName("Name")
       .setDesc("Human-readable collection title (optional).")
       .addText((text) =>
-        text
-          .setValue(config.name ?? "")
-          .onChange(async (value) => {
-            config.name = value || undefined;
-            await saveConfig(this.app.vault, config);
-          })
+        text.setValue(config.name ?? "").onChange(async (value) => {
+          config.name = value || undefined;
+          await saveConfig(this.app.vault, config);
+        }),
       );
 
     new Setting(section)
       .setName("Description")
       .setDesc("Short description of this collection (optional).")
       .addText((text) =>
-        text
-          .setValue(config.description ?? "")
-          .onChange(async (value) => {
-            config.description = value || undefined;
-            await saveConfig(this.app.vault, config);
-          })
+        text.setValue(config.description ?? "").onChange(async (value) => {
+          config.description = value || undefined;
+          await saveConfig(this.app.vault, config);
+        }),
       );
 
     new Setting(section)
@@ -87,9 +98,12 @@ export class MdbaseSettingTab extends PluginSettingTab {
           .setValue(config.settings?.default_validation ?? "warn")
           .onChange(async (value) => {
             config.settings ??= {};
-            config.settings.default_validation = value as "off" | "warn" | "error";
+            config.settings.default_validation = value as
+              | "off"
+              | "warn"
+              | "error";
             await saveConfig(this.app.vault, config);
-          })
+          }),
       );
 
     new Setting(section)
@@ -106,7 +120,7 @@ export class MdbaseSettingTab extends PluginSettingTab {
             config.settings.default_strict =
               value === "true" ? true : value === "warn" ? "warn" : false;
             await saveConfig(this.app.vault, config);
-          })
+          }),
       );
 
     new Setting(section)
@@ -121,7 +135,7 @@ export class MdbaseSettingTab extends PluginSettingTab {
             config.settings.types_folder = value || undefined;
             await saveConfig(this.app.vault, config);
             await this.plugin.reload();
-          })
+          }),
       );
   }
 
@@ -141,7 +155,7 @@ export class MdbaseSettingTab extends PluginSettingTab {
             this.display();
           });
           modal.open();
-        })
+        }),
     );
   }
 
@@ -176,7 +190,10 @@ export class MdbaseSettingTab extends PluginSettingTab {
       meta.push(`fields_present: ${typeDef.match.fields_present.join(", ")}`);
     }
     if (typeDef.description) {
-      info.createDiv({ cls: "mdbase-type-item-meta", text: typeDef.description });
+      info.createDiv({
+        cls: "mdbase-type-item-meta",
+        text: typeDef.description,
+      });
     }
     info.createDiv({ cls: "mdbase-type-item-meta", text: meta.join(" · ") });
 
@@ -213,7 +230,7 @@ class TypeEditorModal extends Modal {
     app: App,
     plugin: MdbasePlugin,
     original: TypeDefinition | null,
-    onSave: () => void
+    onSave: () => void,
   ) {
     super(app);
     this.plugin = plugin;
@@ -225,7 +242,9 @@ class TypeEditorModal extends Modal {
   }
 
   onOpen(): void {
-    this.titleEl.setText(this.original ? `Edit type: ${this.original.name}` : "Add type");
+    this.titleEl.setText(
+      this.original ? `Edit type: ${this.original.name}` : "Add type",
+    );
     this.render();
   }
 
@@ -243,16 +262,16 @@ class TypeEditorModal extends Modal {
         t
           .setValue(this.draft.name)
           .setPlaceholder("note")
-          .onChange((v) => { this.draft.name = v.toLowerCase(); })
+          .onChange((v) => {
+            this.draft.name = v.toLowerCase();
+          }),
       );
 
-    new Setting(contentEl)
-      .setName("Description")
-      .addText((t) =>
-        t
-          .setValue(this.draft.description ?? "")
-          .onChange((v) => { this.draft.description = v || undefined; })
-      );
+    new Setting(contentEl).setName("Description").addText((t) =>
+      t.setValue(this.draft.description ?? "").onChange((v) => {
+        this.draft.description = v || undefined;
+      }),
+    );
 
     new Setting(contentEl)
       .setName("Extends")
@@ -261,7 +280,9 @@ class TypeEditorModal extends Modal {
         t
           .setValue(this.draft.extends ?? "")
           .setPlaceholder("base-type")
-          .onChange((v) => { this.draft.extends = v || undefined; })
+          .onChange((v) => {
+            this.draft.extends = v || undefined;
+          }),
       );
 
     new Setting(contentEl)
@@ -273,11 +294,21 @@ class TypeEditorModal extends Modal {
           .addOption("false", "Allow")
           .addOption("warn", "Warn")
           .addOption("true", "Error")
-          .setValue(this.draft.strict === undefined ? "inherit" : String(this.draft.strict))
+          .setValue(
+            this.draft.strict === undefined
+              ? "inherit"
+              : String(this.draft.strict),
+          )
           .onChange((v) => {
             this.draft.strict =
-              v === "inherit" ? undefined : v === "true" ? true : v === "warn" ? "warn" : false;
-          })
+              v === "inherit"
+                ? undefined
+                : v === "true"
+                  ? true
+                  : v === "warn"
+                    ? "warn"
+                    : false;
+          }),
       );
 
     // --- Match rules ---
@@ -293,10 +324,13 @@ class TypeEditorModal extends Modal {
           .onChange((v) => {
             this.draft.match ??= {};
             this.draft.match.path_glob = v || undefined;
-            if (!this.draft.match.path_glob && !this.draft.match.fields_present?.length) {
+            if (
+              !this.draft.match.path_glob &&
+              !this.draft.match.fields_present?.length
+            ) {
               this.draft.match = undefined;
             }
-          })
+          }),
       );
 
     new Setting(contentEl)
@@ -307,13 +341,21 @@ class TypeEditorModal extends Modal {
           .setValue((this.draft.match?.fields_present ?? []).join(", "))
           .setPlaceholder("due_date, status")
           .onChange((v) => {
-            const fields = v.split(",").map((s) => s.trim()).filter(Boolean);
+            const fields = v
+              .split(",")
+              .map((s) => s.trim())
+              .filter(Boolean);
             this.draft.match ??= {};
-            this.draft.match.fields_present = fields.length ? fields : undefined;
-            if (!this.draft.match.path_glob && !this.draft.match.fields_present?.length) {
+            this.draft.match.fields_present = fields.length
+              ? fields
+              : undefined;
+            if (
+              !this.draft.match.path_glob &&
+              !this.draft.match.fields_present?.length
+            ) {
               this.draft.match = undefined;
             }
-          })
+          }),
       );
 
     // --- Fields ---
@@ -324,12 +366,17 @@ class TypeEditorModal extends Modal {
     new Setting(contentEl).addButton((btn) =>
       btn.setButtonText("Add Field").onClick(() => {
         this.draft.fields ??= {};
-        const modal = new FieldEditorModal(this.app, null, null, (name, def) => {
-          this.draft.fields![name] = def;
-          this.render();
-        });
+        const modal = new FieldEditorModal(
+          this.app,
+          null,
+          null,
+          (name, def) => {
+            this.draft.fields![name] = def;
+            this.render();
+          },
+        );
         modal.open();
-      })
+      }),
     );
 
     // --- Save / Cancel ---
@@ -337,7 +384,10 @@ class TypeEditorModal extends Modal {
     const cancelBtn = actions.createEl("button", { text: "Cancel" });
     cancelBtn.addEventListener("click", () => this.close());
 
-    const saveBtn = actions.createEl("button", { text: "Save", cls: "mod-cta" });
+    const saveBtn = actions.createEl("button", {
+      text: "Save",
+      cls: "mod-cta",
+    });
     saveBtn.addEventListener("click", async () => {
       if (!this.draft.name) {
         new Notice("Type name is required.");
@@ -367,17 +417,26 @@ class TypeEditorModal extends Modal {
       const titleEl = header.createDiv();
       titleEl.createSpan({ cls: "mdbase-field-item-title", text: name });
       titleEl.createSpan({ cls: "mdbase-field-item-type", text: def.type });
-      if (def.required) titleEl.createSpan({ cls: "mdbase-field-item-required", text: "*required" });
+      if (def.required)
+        titleEl.createSpan({
+          cls: "mdbase-field-item-required",
+          text: "*required",
+        });
 
       const actions = header.createDiv({ cls: "mdbase-type-item-actions" });
 
       const editBtn = actions.createEl("button", { text: "Edit" });
       editBtn.addEventListener("click", () => {
-        const modal = new FieldEditorModal(this.app, name, def, (newName, newDef) => {
-          delete this.draft.fields![name];
-          this.draft.fields![newName] = newDef;
-          this.render();
-        });
+        const modal = new FieldEditorModal(
+          this.app,
+          name,
+          def,
+          (newName, newDef) => {
+            delete this.draft.fields![name];
+            this.draft.fields![newName] = newDef;
+            this.render();
+          },
+        );
         modal.open();
       });
 
@@ -405,18 +464,22 @@ class FieldEditorModal extends Modal {
     app: App,
     originalName: string | null,
     originalDef: FieldDef | null,
-    onSave: (name: string, def: FieldDef) => void
+    onSave: (name: string, def: FieldDef) => void,
   ) {
     super(app);
     this.originalName = originalName;
     this.originalDef = originalDef;
     this.onSave = onSave;
     this.draftName = originalName ?? "";
-    this.draft = originalDef ? structuredClone(originalDef) : { type: "string" };
+    this.draft = originalDef
+      ? structuredClone(originalDef)
+      : { type: "string" };
   }
 
   onOpen(): void {
-    this.titleEl.setText(this.originalName ? `Edit field: ${this.originalName}` : "Add field");
+    this.titleEl.setText(
+      this.originalName ? `Edit field: ${this.originalName}` : "Add field",
+    );
     this.render();
   }
 
@@ -424,40 +487,34 @@ class FieldEditorModal extends Modal {
     const { contentEl } = this;
     contentEl.empty();
 
-    new Setting(contentEl)
-      .setName("Field name")
-      .addText((t) =>
-        t
-          .setValue(this.draftName)
-          .setPlaceholder("field_name")
-          .onChange((v) => { this.draftName = v; })
-      );
+    new Setting(contentEl).setName("Field name").addText((t) =>
+      t
+        .setValue(this.draftName)
+        .setPlaceholder("field_name")
+        .onChange((v) => {
+          this.draftName = v;
+        }),
+    );
 
-    new Setting(contentEl)
-      .setName("Type")
-      .addDropdown((d) => {
-        for (const ft of FIELD_TYPES) d.addOption(ft, ft);
-        return d
-          .setValue(this.draft.type)
-          .onChange((v) => {
-            this.draft.type = v as FieldType;
-            this.render();
-          });
+    new Setting(contentEl).setName("Type").addDropdown((d) => {
+      for (const ft of FIELD_TYPES) d.addOption(ft, ft);
+      return d.setValue(this.draft.type).onChange((v) => {
+        this.draft.type = v as FieldType;
+        this.render();
       });
+    });
 
-    new Setting(contentEl)
-      .setName("Required")
-      .addToggle((t) =>
-        t.setValue(this.draft.required ?? false).onChange((v) => { this.draft.required = v || undefined; })
-      );
+    new Setting(contentEl).setName("Required").addToggle((t) =>
+      t.setValue(this.draft.required ?? false).onChange((v) => {
+        this.draft.required = v || undefined;
+      }),
+    );
 
-    new Setting(contentEl)
-      .setName("Description")
-      .addText((t) =>
-        t
-          .setValue(this.draft.description ?? "")
-          .onChange((v) => { this.draft.description = v || undefined; })
-      );
+    new Setting(contentEl).setName("Description").addText((t) =>
+      t.setValue(this.draft.description ?? "").onChange((v) => {
+        this.draft.description = v || undefined;
+      }),
+    );
 
     // Type-specific constraints
     this.renderTypeConstraints(contentEl);
@@ -466,7 +523,10 @@ class FieldEditorModal extends Modal {
     const cancelBtn = actions.createEl("button", { text: "Cancel" });
     cancelBtn.addEventListener("click", () => this.close());
 
-    const saveBtn = actions.createEl("button", { text: "Save field", cls: "mod-cta" });
+    const saveBtn = actions.createEl("button", {
+      text: "Save field",
+      cls: "mod-cta",
+    });
     saveBtn.addEventListener("click", () => {
       if (!this.draftName) {
         new Notice("Field name is required.");
@@ -485,30 +545,32 @@ class FieldEditorModal extends Modal {
         t
           .setValue(String(this.draft.min_length ?? ""))
           .setPlaceholder("0")
-          .onChange((v) => { this.draft.min_length = v ? parseInt(v) : undefined; })
+          .onChange((v) => {
+            this.draft.min_length = v ? parseInt(v) : undefined;
+          }),
       );
       new Setting(el).setName("Max length").addText((t) =>
-        t
-          .setValue(String(this.draft.max_length ?? ""))
-          .onChange((v) => { this.draft.max_length = v ? parseInt(v) : undefined; })
+        t.setValue(String(this.draft.max_length ?? "")).onChange((v) => {
+          this.draft.max_length = v ? parseInt(v) : undefined;
+        }),
       );
       new Setting(el).setName("Pattern (regex)").addText((t) =>
-        t
-          .setValue(this.draft.pattern ?? "")
-          .onChange((v) => { this.draft.pattern = v || undefined; })
+        t.setValue(this.draft.pattern ?? "").onChange((v) => {
+          this.draft.pattern = v || undefined;
+        }),
       );
     }
 
     if (type === "integer" || type === "number") {
       new Setting(el).setName("Min").addText((t) =>
-        t
-          .setValue(String(this.draft.min ?? ""))
-          .onChange((v) => { this.draft.min = v ? Number(v) : undefined; })
+        t.setValue(String(this.draft.min ?? "")).onChange((v) => {
+          this.draft.min = v ? Number(v) : undefined;
+        }),
       );
       new Setting(el).setName("Max").addText((t) =>
-        t
-          .setValue(String(this.draft.max ?? ""))
-          .onChange((v) => { this.draft.max = v ? Number(v) : undefined; })
+        t.setValue(String(this.draft.max ?? "")).onChange((v) => {
+          this.draft.max = v ? Number(v) : undefined;
+        }),
       );
     }
 
@@ -517,26 +579,29 @@ class FieldEditorModal extends Modal {
         .setName("Values")
         .setDesc("Comma-separated list of allowed values.")
         .addText((t) =>
-          t
-            .setValue((this.draft.values ?? []).join(", "))
-            .onChange((v) => {
-              this.draft.values = v.split(",").map((s) => s.trim()).filter(Boolean);
-            })
+          t.setValue((this.draft.values ?? []).join(", ")).onChange((v) => {
+            this.draft.values = v
+              .split(",")
+              .map((s) => s.trim())
+              .filter(Boolean);
+          }),
         );
     }
 
     if (type === "list") {
       new Setting(el).setName("Element type").addDropdown((d) => {
-        const elementTypes: FieldType[] = FIELD_TYPES.filter((f) => f !== "list" && f !== "object");
+        const elementTypes: FieldType[] = FIELD_TYPES.filter(
+          (f) => f !== "list" && f !== "object",
+        );
         for (const ft of elementTypes) d.addOption(ft, ft);
-        return d
-          .setValue(this.draft.element_type ?? "string")
-          .onChange((v) => { this.draft.element_type = v as FieldType; });
+        return d.setValue(this.draft.element_type ?? "string").onChange((v) => {
+          this.draft.element_type = v as FieldType;
+        });
       });
       new Setting(el).setName("Unique elements").addToggle((t) =>
-        t
-          .setValue(this.draft.unique_elements ?? false)
-          .onChange((v) => { this.draft.unique_elements = v || undefined; })
+        t.setValue(this.draft.unique_elements ?? false).onChange((v) => {
+          this.draft.unique_elements = v || undefined;
+        }),
       );
     }
   }

--- a/src/validation/validator.ts
+++ b/src/validation/validator.ts
@@ -1,4 +1,8 @@
-import type { MdbaseConfig, TypeDefinition, ValidationIssue } from "../types.ts";
+import type {
+  MdbaseConfig,
+  TypeDefinition,
+  ValidationIssue,
+} from "../types.ts";
 import { getDefaultStrict, getDefaultValidation } from "../types.ts";
 import { validateFieldValue } from "../schema/fieldTypes.ts";
 
@@ -8,7 +12,7 @@ export function validateFile(
   filePath: string,
   frontmatter: Record<string, unknown>,
   matchedTypes: TypeDefinition[],
-  config: MdbaseConfig
+  config: MdbaseConfig,
 ): ValidationIssue[] {
   const mode = getDefaultValidation(config);
   if (mode === "off") return [];
@@ -17,7 +21,12 @@ export function validateFile(
   const issues: ValidationIssue[] = [];
 
   for (const typeDef of matchedTypes) {
-    const typeIssues = validateAgainstType(filePath, frontmatter, typeDef, config);
+    const typeIssues = validateAgainstType(
+      filePath,
+      frontmatter,
+      typeDef,
+      config,
+    );
     issues.push(...typeIssues);
   }
 
@@ -28,7 +37,7 @@ function validateAgainstType(
   filePath: string,
   frontmatter: Record<string, unknown>,
   typeDef: TypeDefinition,
-  config: MdbaseConfig
+  config: MdbaseConfig,
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const fields = typeDef.fields ?? {};


### PR DESCRIPTION
## Summary

- Adds prettier with config that ignores `main.js` and `test-vault/`
- Adds a husky pre-commit hook that runs lint-staged to format staged files on every commit
- Adds `format` and `format:check` npm scripts
- Adds a `format` CI job that runs `pnpm format:check` on every push/PR
- Formats all existing source files in a separate commit

## Notes

The pre-commit hook calls `node_modules/.bin/lint-staged` directly rather than `pnpm exec lint-staged` — `pnpm exec` strips the volta-managed `node` from `PATH`, causing the lint-staged shell wrapper to fail.

## Test plan

- [ ] Run `pnpm format:check` locally — should pass
- [ ] Make a change to a `.ts` file without formatting it, stage it, and commit — hook should auto-format it
- [ ] Verify CI `format` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)