### PR TITLE
Introduce Svelte 5 for plugin UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 *.map
 
+# Claude
+.claude/worktrees
+
 # Obsidian vault generated files
 test-vault/.obsidian/workspace.json
 test-vault/.obsidian/workspace-mobile.json

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,6 +1,7 @@
 import esbuild from "esbuild";
 import process from "process";
 import builtins from "builtin-modules";
+import sveltePlugin from "esbuild-svelte";
 
 const prod = process.argv[2] === "production";
 
@@ -23,6 +24,7 @@ const context = await esbuild.context({
     "@lezer/lr",
     ...builtins,
   ],
+  plugins: [sveltePlugin({ compilerOptions: { css: "injected" } })],
   format: "cjs",
   target: "es2018",
   logLevel: "info",

--- a/main.js
+++ b/main.js
@@ -4104,6 +4104,13 @@ var MdbasePlugin = class extends import_obsidian4.Plugin {
         }
       })
     );
+    this.registerEvent(
+      this.app.vault.on("modify", (file) => {
+        if (file.path === CONFIG_FILENAME) {
+          this.reload();
+        }
+      })
+    );
   }
   async initializeCollection() {
     this.config = await createDefaultConfig(this.app.vault);

--- a/main.js
+++ b/main.js
@@ -4,6 +4,10 @@ var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __typeError = (msg) => {
+  throw TypeError(msg);
+};
+var __defNormalProp = (obj, key2, value) => key2 in obj ? __defProp(obj, key2, { enumerable: true, configurable: true, writable: true, value }) : obj[key2] = value;
 var __commonJS = (cb, mod) => function __require() {
   return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
 };
@@ -13,9 +17,9 @@ var __export = (target, all) => {
 };
 var __copyProps = (to, from, except, desc) => {
   if (from && typeof from === "object" || typeof from === "function") {
-    for (let key of __getOwnPropNames(from))
-      if (!__hasOwnProp.call(to, key) && key !== except)
-        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    for (let key2 of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key2) && key2 !== except)
+        __defProp(to, key2, { get: () => from[key2], enumerable: !(desc = __getOwnPropDesc(from, key2)) || desc.enumerable });
   }
   return to;
 };
@@ -28,10 +32,16 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __publicField = (obj, key2, value) => __defNormalProp(obj, typeof key2 !== "symbol" ? key2 + "" : key2, value);
+var __accessCheck = (obj, member, msg) => member.has(obj) || __typeError("Cannot " + msg);
+var __privateGet = (obj, member, getter) => (__accessCheck(obj, member, "read from private field"), getter ? getter.call(obj) : member.get(obj));
+var __privateAdd = (obj, member, value) => member.has(obj) ? __typeError("Cannot add the same private member more than once") : member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
+var __privateSet = (obj, member, value, setter) => (__accessCheck(obj, member, "write to private field"), setter ? setter.call(obj, value) : member.set(obj, value), value);
+var __privateMethod = (obj, member, method) => (__accessCheck(obj, member, "access private method"), method);
 
-// node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/utils.js
+// ../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/utils.js
 var require_utils = __commonJS({
-  "node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/utils.js"(exports) {
+  "../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/utils.js"(exports) {
     "use strict";
     exports.isInteger = (num) => {
       if (typeof num === "number") {
@@ -48,8 +58,8 @@ var require_utils = __commonJS({
       if (!exports.isInteger(min) || !exports.isInteger(max)) return false;
       return (Number(max) - Number(min)) / Number(step) >= limit;
     };
-    exports.escapeNode = (block, n = 0, type) => {
-      const node = block.nodes[n];
+    exports.escapeNode = (block2, n = 0, type) => {
+      const node = block2.nodes[n];
       if (!node) return;
       if (type && node.type === type || node.type === "open" || node.type === "close") {
         if (node.escaped !== true) {
@@ -66,15 +76,15 @@ var require_utils = __commonJS({
       }
       return false;
     };
-    exports.isInvalidBrace = (block) => {
-      if (block.type !== "brace") return false;
-      if (block.invalid === true || block.dollar) return true;
-      if (block.commas >> 0 + block.ranges >> 0 === 0) {
-        block.invalid = true;
+    exports.isInvalidBrace = (block2) => {
+      if (block2.type !== "brace") return false;
+      if (block2.invalid === true || block2.dollar) return true;
+      if (block2.commas >> 0 + block2.ranges >> 0 === 0) {
+        block2.invalid = true;
         return true;
       }
-      if (block.open !== true || block.close !== true) {
-        block.invalid = true;
+      if (block2.open !== true || block2.close !== true) {
+        block2.invalid = true;
         return true;
       }
       return false;
@@ -111,9 +121,9 @@ var require_utils = __commonJS({
   }
 });
 
-// node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/stringify.js
+// ../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/stringify.js
 var require_stringify = __commonJS({
-  "node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/stringify.js"(exports, module2) {
+  "../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/stringify.js"(exports, module2) {
     "use strict";
     var utils = require_utils();
     module2.exports = (ast, options = {}) => {
@@ -131,8 +141,8 @@ var require_stringify = __commonJS({
           return node.value;
         }
         if (node.nodes) {
-          for (const child of node.nodes) {
-            output += stringify(child);
+          for (const child2 of node.nodes) {
+            output += stringify(child2);
           }
         }
         return output;
@@ -142,9 +152,9 @@ var require_stringify = __commonJS({
   }
 });
 
-// node_modules/.pnpm/is-number@7.0.0/node_modules/is-number/index.js
+// ../../../node_modules/.pnpm/is-number@7.0.0/node_modules/is-number/index.js
 var require_is_number = __commonJS({
-  "node_modules/.pnpm/is-number@7.0.0/node_modules/is-number/index.js"(exports, module2) {
+  "../../../node_modules/.pnpm/is-number@7.0.0/node_modules/is-number/index.js"(exports, module2) {
     "use strict";
     module2.exports = function(num) {
       if (typeof num === "number") {
@@ -158,9 +168,9 @@ var require_is_number = __commonJS({
   }
 });
 
-// node_modules/.pnpm/to-regex-range@5.0.1/node_modules/to-regex-range/index.js
+// ../../../node_modules/.pnpm/to-regex-range@5.0.1/node_modules/to-regex-range/index.js
 var require_to_regex_range = __commonJS({
-  "node_modules/.pnpm/to-regex-range@5.0.1/node_modules/to-regex-range/index.js"(exports, module2) {
+  "../../../node_modules/.pnpm/to-regex-range@5.0.1/node_modules/to-regex-range/index.js"(exports, module2) {
     "use strict";
     var isNumber = require_is_number();
     var toRegexRange = (min, max, options) => {
@@ -179,9 +189,9 @@ var require_to_regex_range = __commonJS({
       }
       let relax = String(opts.relaxZeros);
       let shorthand = String(opts.shorthand);
-      let capture = String(opts.capture);
+      let capture2 = String(opts.capture);
       let wrap = String(opts.wrap);
-      let cacheKey = min + ":" + max + "=" + relax + shorthand + capture + wrap;
+      let cacheKey = min + ":" + max + "=" + relax + shorthand + capture2 + wrap;
       if (toRegexRange.cache.hasOwnProperty(cacheKey)) {
         return toRegexRange.cache[cacheKey].result;
       }
@@ -198,31 +208,31 @@ var require_to_regex_range = __commonJS({
         return `(?:${result})`;
       }
       let isPadded = hasPadding(min) || hasPadding(max);
-      let state = { min, max, a, b };
+      let state2 = { min, max, a, b };
       let positives = [];
       let negatives = [];
       if (isPadded) {
-        state.isPadded = isPadded;
-        state.maxLen = String(state.max).length;
+        state2.isPadded = isPadded;
+        state2.maxLen = String(state2.max).length;
       }
       if (a < 0) {
         let newMin = b < 0 ? Math.abs(b) : 1;
-        negatives = splitToPatterns(newMin, Math.abs(a), state, opts);
-        a = state.a = 0;
+        negatives = splitToPatterns(newMin, Math.abs(a), state2, opts);
+        a = state2.a = 0;
       }
       if (b >= 0) {
-        positives = splitToPatterns(a, b, state, opts);
+        positives = splitToPatterns(a, b, state2, opts);
       }
-      state.negatives = negatives;
-      state.positives = positives;
-      state.result = collatePatterns(negatives, positives, opts);
+      state2.negatives = negatives;
+      state2.positives = positives;
+      state2.result = collatePatterns(negatives, positives, opts);
       if (opts.capture === true) {
-        state.result = `(${state.result})`;
+        state2.result = `(${state2.result})`;
       } else if (opts.wrap !== false && positives.length + negatives.length > 1) {
-        state.result = `(?:${state.result})`;
+        state2.result = `(?:${state2.result})`;
       }
-      toRegexRange.cache[cacheKey] = state;
-      return state.result;
+      toRegexRange.cache[cacheKey] = state2;
+      return state2.result;
     };
     function collatePatterns(neg, pos, options) {
       let onlyNegative = filterPatterns(neg, pos, "-", false, options) || [];
@@ -323,8 +333,8 @@ var require_to_regex_range = __commonJS({
     function compare(a, b) {
       return a > b ? 1 : b > a ? -1 : 0;
     }
-    function contains(arr, key, val) {
-      return arr.some((ele) => ele[key] === val);
+    function contains(arr, key2, val) {
+      return arr.some((ele) => ele[key2] === val);
     }
     function countNines(min, len) {
       return Number(String(min).slice(0, -len) + "9".repeat(len));
@@ -369,9 +379,9 @@ var require_to_regex_range = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fill-range@7.1.1/node_modules/fill-range/index.js
+// ../../../node_modules/.pnpm/fill-range@7.1.1/node_modules/fill-range/index.js
 var require_fill_range = __commonJS({
-  "node_modules/.pnpm/fill-range@7.1.1/node_modules/fill-range/index.js"(exports, module2) {
+  "../../../node_modules/.pnpm/fill-range@7.1.1/node_modules/fill-range/index.js"(exports, module2) {
     "use strict";
     var util = require("util");
     var toRegexRange = require_to_regex_range();
@@ -385,11 +395,11 @@ var require_fill_range = __commonJS({
     var isNumber = (num) => Number.isInteger(+num);
     var zeros = (input) => {
       let value = `${input}`;
-      let index = -1;
+      let index2 = -1;
       if (value[0] === "-") value = value.slice(1);
       if (value === "0") return false;
-      while (value[++index] === "0") ;
-      return index > 0;
+      while (value[++index2] === "0") ;
+      return index2 > 0;
     };
     var stringify = (start, end, options) => {
       if (typeof start === "string" || typeof end === "string") {
@@ -492,17 +502,17 @@ var require_fill_range = __commonJS({
         return toRange(toMaxLen(start, maxLen), toMaxLen(end, maxLen), true, options);
       }
       let parts = { negatives: [], positives: [] };
-      let push = (num) => parts[num < 0 ? "negatives" : "positives"].push(Math.abs(num));
+      let push2 = (num) => parts[num < 0 ? "negatives" : "positives"].push(Math.abs(num));
       let range = [];
-      let index = 0;
+      let index2 = 0;
       while (descending ? a >= b : a <= b) {
         if (options.toRegex === true && step > 1) {
-          push(a);
+          push2(a);
         } else {
-          range.push(pad(format(a, index), maxLen, toNumber));
+          range.push(pad(format(a, index2), maxLen, toNumber));
         }
         a = descending ? a - step : a + step;
-        index++;
+        index2++;
       }
       if (options.toRegex === true) {
         return step > 1 ? toSequence(parts, options, maxLen) : toRegex(range, null, { wrap: false, ...options });
@@ -523,11 +533,11 @@ var require_fill_range = __commonJS({
         return toRange(min, max, false, options);
       }
       let range = [];
-      let index = 0;
+      let index2 = 0;
       while (descending ? a >= b : a <= b) {
-        range.push(format(a, index));
+        range.push(format(a, index2));
         a = descending ? a - step : a + step;
-        index++;
+        index2++;
       }
       if (options.toRegex === true) {
         return toRegex(range, null, { wrap: false, options });
@@ -563,9 +573,9 @@ var require_fill_range = __commonJS({
   }
 });
 
-// node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/compile.js
+// ../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/compile.js
 var require_compile = __commonJS({
-  "node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/compile.js"(exports, module2) {
+  "../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/compile.js"(exports, module2) {
     "use strict";
     var fill = require_fill_range();
     var utils = require_utils();
@@ -603,8 +613,8 @@ var require_compile = __commonJS({
           }
         }
         if (node.nodes) {
-          for (const child of node.nodes) {
-            output += walk(child, node);
+          for (const child2 of node.nodes) {
+            output += walk(child2, node);
           }
         }
         return output;
@@ -615,14 +625,14 @@ var require_compile = __commonJS({
   }
 });
 
-// node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/expand.js
+// ../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/expand.js
 var require_expand = __commonJS({
-  "node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/expand.js"(exports, module2) {
+  "../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/expand.js"(exports, module2) {
     "use strict";
     var fill = require_fill_range();
     var stringify = require_stringify();
     var utils = require_utils();
-    var append = (queue = "", stash = "", enclose = false) => {
+    var append2 = (queue = "", stash = "", enclose = false) => {
       const result = [];
       queue = [].concat(queue);
       stash = [].concat(stash);
@@ -633,12 +643,12 @@ var require_expand = __commonJS({
       for (const item of queue) {
         if (Array.isArray(item)) {
           for (const value of item) {
-            result.push(append(value, stash, enclose));
+            result.push(append2(value, stash, enclose));
           }
         } else {
           for (let ele of stash) {
             if (enclose === true && typeof ele === "string") ele = `{${ele}}`;
-            result.push(Array.isArray(ele) ? append(item, ele, enclose) : item + ele);
+            result.push(Array.isArray(ele) ? append2(item, ele, enclose) : item + ele);
           }
         }
       }
@@ -655,11 +665,11 @@ var require_expand = __commonJS({
           q = p.queue;
         }
         if (node.invalid || node.dollar) {
-          q.push(append(q.pop(), stringify(node, options)));
+          q.push(append2(q.pop(), stringify(node, options)));
           return;
         }
         if (node.type === "brace" && node.invalid !== true && node.nodes.length === 2) {
-          q.push(append(q.pop(), ["{}"]));
+          q.push(append2(q.pop(), ["{}"]));
           return;
         }
         if (node.nodes && node.ranges > 0) {
@@ -671,34 +681,34 @@ var require_expand = __commonJS({
           if (range.length === 0) {
             range = stringify(node, options);
           }
-          q.push(append(q.pop(), range));
+          q.push(append2(q.pop(), range));
           node.nodes = [];
           return;
         }
         const enclose = utils.encloseBrace(node);
         let queue = node.queue;
-        let block = node;
-        while (block.type !== "brace" && block.type !== "root" && block.parent) {
-          block = block.parent;
-          queue = block.queue;
+        let block2 = node;
+        while (block2.type !== "brace" && block2.type !== "root" && block2.parent) {
+          block2 = block2.parent;
+          queue = block2.queue;
         }
         for (let i = 0; i < node.nodes.length; i++) {
-          const child = node.nodes[i];
-          if (child.type === "comma" && node.type === "brace") {
+          const child2 = node.nodes[i];
+          if (child2.type === "comma" && node.type === "brace") {
             if (i === 1) queue.push("");
             queue.push("");
             continue;
           }
-          if (child.type === "close") {
-            q.push(append(q.pop(), queue, enclose));
+          if (child2.type === "close") {
+            q.push(append2(q.pop(), queue, enclose));
             continue;
           }
-          if (child.value && child.type !== "open") {
-            queue.push(append(queue.pop(), child.value));
+          if (child2.value && child2.type !== "open") {
+            queue.push(append2(queue.pop(), child2.value));
             continue;
           }
-          if (child.nodes) {
-            walk(child, node);
+          if (child2.nodes) {
+            walk(child2, node);
           }
         }
         return queue;
@@ -709,9 +719,9 @@ var require_expand = __commonJS({
   }
 });
 
-// node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/constants.js
+// ../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/constants.js
 var require_constants = __commonJS({
-  "node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/constants.js"(exports, module2) {
+  "../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/constants.js"(exports, module2) {
     "use strict";
     module2.exports = {
       MAX_LENGTH: 1e4,
@@ -810,9 +820,9 @@ var require_constants = __commonJS({
   }
 });
 
-// node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/parse.js
+// ../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/parse.js
 var require_parse = __commonJS({
-  "node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/parse.js"(exports, module2) {
+  "../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/lib/parse.js"(exports, module2) {
     "use strict";
     var stringify = require_stringify();
     var {
@@ -854,16 +864,16 @@ var require_parse = __commonJS({
         throw new SyntaxError(`Input length (${input.length}), exceeds max characters (${max})`);
       }
       const ast = { type: "root", input, nodes: [] };
-      const stack = [ast];
-      let block = ast;
+      const stack2 = [ast];
+      let block2 = ast;
       let prev = ast;
       let brackets = 0;
       const length = input.length;
-      let index = 0;
+      let index2 = 0;
       let depth = 0;
       let value;
-      const advance = () => input[index++];
-      const push = (node) => {
+      const advance = () => input[index2++];
+      const push2 = (node) => {
         if (node.type === "text" && prev.type === "dot") {
           prev.type = "text";
         }
@@ -871,89 +881,89 @@ var require_parse = __commonJS({
           prev.value += node.value;
           return;
         }
-        block.nodes.push(node);
-        node.parent = block;
+        block2.nodes.push(node);
+        node.parent = block2;
         node.prev = prev;
         prev = node;
         return node;
       };
-      push({ type: "bos" });
-      while (index < length) {
-        block = stack[stack.length - 1];
+      push2({ type: "bos" });
+      while (index2 < length) {
+        block2 = stack2[stack2.length - 1];
         value = advance();
         if (value === CHAR_ZERO_WIDTH_NOBREAK_SPACE || value === CHAR_NO_BREAK_SPACE) {
           continue;
         }
         if (value === CHAR_BACKSLASH) {
-          push({ type: "text", value: (options.keepEscaping ? value : "") + advance() });
+          push2({ type: "text", value: (options.keepEscaping ? value : "") + advance() });
           continue;
         }
         if (value === CHAR_RIGHT_SQUARE_BRACKET) {
-          push({ type: "text", value: "\\" + value });
+          push2({ type: "text", value: "\\" + value });
           continue;
         }
         if (value === CHAR_LEFT_SQUARE_BRACKET) {
           brackets++;
-          let next;
-          while (index < length && (next = advance())) {
-            value += next;
-            if (next === CHAR_LEFT_SQUARE_BRACKET) {
+          let next2;
+          while (index2 < length && (next2 = advance())) {
+            value += next2;
+            if (next2 === CHAR_LEFT_SQUARE_BRACKET) {
               brackets++;
               continue;
             }
-            if (next === CHAR_BACKSLASH) {
+            if (next2 === CHAR_BACKSLASH) {
               value += advance();
               continue;
             }
-            if (next === CHAR_RIGHT_SQUARE_BRACKET) {
+            if (next2 === CHAR_RIGHT_SQUARE_BRACKET) {
               brackets--;
               if (brackets === 0) {
                 break;
               }
             }
           }
-          push({ type: "text", value });
+          push2({ type: "text", value });
           continue;
         }
         if (value === CHAR_LEFT_PARENTHESES) {
-          block = push({ type: "paren", nodes: [] });
-          stack.push(block);
-          push({ type: "text", value });
+          block2 = push2({ type: "paren", nodes: [] });
+          stack2.push(block2);
+          push2({ type: "text", value });
           continue;
         }
         if (value === CHAR_RIGHT_PARENTHESES) {
-          if (block.type !== "paren") {
-            push({ type: "text", value });
+          if (block2.type !== "paren") {
+            push2({ type: "text", value });
             continue;
           }
-          block = stack.pop();
-          push({ type: "text", value });
-          block = stack[stack.length - 1];
+          block2 = stack2.pop();
+          push2({ type: "text", value });
+          block2 = stack2[stack2.length - 1];
           continue;
         }
         if (value === CHAR_DOUBLE_QUOTE || value === CHAR_SINGLE_QUOTE || value === CHAR_BACKTICK) {
           const open = value;
-          let next;
+          let next2;
           if (options.keepQuotes !== true) {
             value = "";
           }
-          while (index < length && (next = advance())) {
-            if (next === CHAR_BACKSLASH) {
-              value += next + advance();
+          while (index2 < length && (next2 = advance())) {
+            if (next2 === CHAR_BACKSLASH) {
+              value += next2 + advance();
               continue;
             }
-            if (next === open) {
-              if (options.keepQuotes === true) value += next;
+            if (next2 === open) {
+              if (options.keepQuotes === true) value += next2;
               break;
             }
-            value += next;
+            value += next2;
           }
-          push({ type: "text", value });
+          push2({ type: "text", value });
           continue;
         }
         if (value === CHAR_LEFT_CURLY_BRACE) {
           depth++;
-          const dollar = prev.value && prev.value.slice(-1) === "$" || block.dollar === true;
+          const dollar = prev.value && prev.value.slice(-1) === "$" || block2.dollar === true;
           const brace = {
             type: "brace",
             open: true,
@@ -964,52 +974,52 @@ var require_parse = __commonJS({
             ranges: 0,
             nodes: []
           };
-          block = push(brace);
-          stack.push(block);
-          push({ type: "open", value });
+          block2 = push2(brace);
+          stack2.push(block2);
+          push2({ type: "open", value });
           continue;
         }
         if (value === CHAR_RIGHT_CURLY_BRACE) {
-          if (block.type !== "brace") {
-            push({ type: "text", value });
+          if (block2.type !== "brace") {
+            push2({ type: "text", value });
             continue;
           }
           const type = "close";
-          block = stack.pop();
-          block.close = true;
-          push({ type, value });
+          block2 = stack2.pop();
+          block2.close = true;
+          push2({ type, value });
           depth--;
-          block = stack[stack.length - 1];
+          block2 = stack2[stack2.length - 1];
           continue;
         }
         if (value === CHAR_COMMA && depth > 0) {
-          if (block.ranges > 0) {
-            block.ranges = 0;
-            const open = block.nodes.shift();
-            block.nodes = [open, { type: "text", value: stringify(block) }];
+          if (block2.ranges > 0) {
+            block2.ranges = 0;
+            const open = block2.nodes.shift();
+            block2.nodes = [open, { type: "text", value: stringify(block2) }];
           }
-          push({ type: "comma", value });
-          block.commas++;
+          push2({ type: "comma", value });
+          block2.commas++;
           continue;
         }
-        if (value === CHAR_DOT && depth > 0 && block.commas === 0) {
-          const siblings = block.nodes;
+        if (value === CHAR_DOT && depth > 0 && block2.commas === 0) {
+          const siblings = block2.nodes;
           if (depth === 0 || siblings.length === 0) {
-            push({ type: "text", value });
+            push2({ type: "text", value });
             continue;
           }
           if (prev.type === "dot") {
-            block.range = [];
+            block2.range = [];
             prev.value += value;
             prev.type = "range";
-            if (block.nodes.length !== 3 && block.nodes.length !== 5) {
-              block.invalid = true;
-              block.ranges = 0;
+            if (block2.nodes.length !== 3 && block2.nodes.length !== 5) {
+              block2.invalid = true;
+              block2.ranges = 0;
               prev.type = "text";
               continue;
             }
-            block.ranges++;
-            block.args = [];
+            block2.ranges++;
+            block2.args = [];
             continue;
           }
           if (prev.type === "range") {
@@ -1017,18 +1027,18 @@ var require_parse = __commonJS({
             const before = siblings[siblings.length - 1];
             before.value += prev.value + value;
             prev = before;
-            block.ranges--;
+            block2.ranges--;
             continue;
           }
-          push({ type: "dot", value });
+          push2({ type: "dot", value });
           continue;
         }
-        push({ type: "text", value });
+        push2({ type: "text", value });
       }
       do {
-        block = stack.pop();
-        if (block.type !== "root") {
-          block.nodes.forEach((node) => {
+        block2 = stack2.pop();
+        if (block2.type !== "root") {
+          block2.nodes.forEach((node) => {
             if (!node.nodes) {
               if (node.type === "open") node.isOpen = true;
               if (node.type === "close") node.isClose = true;
@@ -1036,21 +1046,21 @@ var require_parse = __commonJS({
               node.invalid = true;
             }
           });
-          const parent = stack[stack.length - 1];
-          const index2 = parent.nodes.indexOf(block);
-          parent.nodes.splice(index2, 1, ...block.nodes);
+          const parent = stack2[stack2.length - 1];
+          const index3 = parent.nodes.indexOf(block2);
+          parent.nodes.splice(index3, 1, ...block2.nodes);
         }
-      } while (stack.length > 0);
-      push({ type: "eos" });
+      } while (stack2.length > 0);
+      push2({ type: "eos" });
       return ast;
     };
     module2.exports = parse;
   }
 });
 
-// node_modules/.pnpm/braces@3.0.3/node_modules/braces/index.js
+// ../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/index.js
 var require_braces = __commonJS({
-  "node_modules/.pnpm/braces@3.0.3/node_modules/braces/index.js"(exports, module2) {
+  "../../../node_modules/.pnpm/braces@3.0.3/node_modules/braces/index.js"(exports, module2) {
     "use strict";
     var stringify = require_stringify();
     var compile = require_compile();
@@ -1111,9 +1121,9 @@ var require_braces = __commonJS({
   }
 });
 
-// node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/constants.js
+// ../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/constants.js
 var require_constants2 = __commonJS({
-  "node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/constants.js"(exports, module2) {
+  "../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/constants.js"(exports, module2) {
     "use strict";
     var path = require("path");
     var WIN_SLASH = "\\\\/";
@@ -1312,9 +1322,9 @@ var require_constants2 = __commonJS({
   }
 });
 
-// node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/utils.js
+// ../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/utils.js
 var require_utils2 = __commonJS({
-  "node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/utils.js"(exports) {
+  "../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/utils.js"(exports) {
     "use strict";
     var path = require("path");
     var win32 = process.platform === "win32";
@@ -1353,19 +1363,19 @@ var require_utils2 = __commonJS({
       if (input[idx - 1] === "\\") return exports.escapeLast(input, char, idx - 1);
       return `${input.slice(0, idx)}\\${input.slice(idx)}`;
     };
-    exports.removePrefix = (input, state = {}) => {
+    exports.removePrefix = (input, state2 = {}) => {
       let output = input;
       if (output.startsWith("./")) {
         output = output.slice(2);
-        state.prefix = "./";
+        state2.prefix = "./";
       }
       return output;
     };
-    exports.wrapOutput = (input, state = {}, options = {}) => {
+    exports.wrapOutput = (input, state2 = {}, options = {}) => {
       const prepend = options.contains ? "" : "^";
-      const append = options.contains ? "" : "$";
-      let output = `${prepend}(?:${input})${append}`;
-      if (state.negated === true) {
+      const append2 = options.contains ? "" : "$";
+      let output = `${prepend}(?:${input})${append2}`;
+      if (state2.negated === true) {
         output = `(?:^(?!${output}).*$)`;
       }
       return output;
@@ -1373,9 +1383,9 @@ var require_utils2 = __commonJS({
   }
 });
 
-// node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/scan.js
+// ../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/scan.js
 var require_scan = __commonJS({
-  "node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/scan.js"(exports, module2) {
+  "../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/scan.js"(exports, module2) {
     "use strict";
     var utils = require_utils2();
     var {
@@ -1426,7 +1436,7 @@ var require_scan = __commonJS({
       const tokens = [];
       const parts = [];
       let str = input;
-      let index = -1;
+      let index2 = -1;
       let start = 0;
       let lastIndex = 0;
       let isBrace = false;
@@ -1443,15 +1453,15 @@ var require_scan = __commonJS({
       let prev;
       let code;
       let token = { value: "", depth: 0, isGlob: false };
-      const eos = () => index >= length;
-      const peek = () => str.charCodeAt(index + 1);
+      const eos = () => index2 >= length;
+      const peek = () => str.charCodeAt(index2 + 1);
       const advance = () => {
         prev = code;
-        return str.charCodeAt(++index);
+        return str.charCodeAt(++index2);
       };
-      while (index < length) {
+      while (index2 < length) {
         code = advance();
-        let next;
+        let next2;
         if (code === CHAR_BACKWARD_SLASH) {
           backslashes = token.backslashes = true;
           code = advance();
@@ -1506,15 +1516,15 @@ var require_scan = __commonJS({
           break;
         }
         if (code === CHAR_FORWARD_SLASH) {
-          slashes.push(index);
+          slashes.push(index2);
           tokens.push(token);
           token = { value: "", depth: 0, isGlob: false };
           if (finished === true) continue;
-          if (prev === CHAR_DOT && index === start + 1) {
+          if (prev === CHAR_DOT && index2 === start + 1) {
             start += 2;
             continue;
           }
-          lastIndex = index + 1;
+          lastIndex = index2 + 1;
           continue;
         }
         if (opts.noext !== true) {
@@ -1523,7 +1533,7 @@ var require_scan = __commonJS({
             isGlob = token.isGlob = true;
             isExtglob = token.isExtglob = true;
             finished = true;
-            if (code === CHAR_EXCLAMATION_MARK && index === start) {
+            if (code === CHAR_EXCLAMATION_MARK && index2 === start) {
               negatedExtglob = true;
             }
             if (scanToEnd === true) {
@@ -1562,13 +1572,13 @@ var require_scan = __commonJS({
           break;
         }
         if (code === CHAR_LEFT_SQUARE_BRACKET) {
-          while (eos() !== true && (next = advance())) {
-            if (next === CHAR_BACKWARD_SLASH) {
+          while (eos() !== true && (next2 = advance())) {
+            if (next2 === CHAR_BACKWARD_SLASH) {
               backslashes = token.backslashes = true;
               advance();
               continue;
             }
-            if (next === CHAR_RIGHT_SQUARE_BRACKET) {
+            if (next2 === CHAR_RIGHT_SQUARE_BRACKET) {
               isBracket = token.isBracket = true;
               isGlob = token.isGlob = true;
               finished = true;
@@ -1580,7 +1590,7 @@ var require_scan = __commonJS({
           }
           break;
         }
-        if (opts.nonegate !== true && code === CHAR_EXCLAMATION_MARK && index === start) {
+        if (opts.nonegate !== true && code === CHAR_EXCLAMATION_MARK && index2 === start) {
           negated = token.negated = true;
           start++;
           continue;
@@ -1643,7 +1653,7 @@ var require_scan = __commonJS({
           base = utils.removeBackslashes(base);
         }
       }
-      const state = {
+      const state2 = {
         prefix,
         input,
         start,
@@ -1658,11 +1668,11 @@ var require_scan = __commonJS({
         negatedExtglob
       };
       if (opts.tokens === true) {
-        state.maxDepth = 0;
+        state2.maxDepth = 0;
         if (!isPathSeparator(code)) {
           tokens.push(token);
         }
-        state.tokens = tokens;
+        state2.tokens = tokens;
       }
       if (opts.parts === true || opts.tokens === true) {
         let prevIndex;
@@ -1678,7 +1688,7 @@ var require_scan = __commonJS({
               tokens[idx].value = value;
             }
             depth(tokens[idx]);
-            state.maxDepth += tokens[idx].depth;
+            state2.maxDepth += tokens[idx].depth;
           }
           if (idx !== 0 || value !== "") {
             parts.push(value);
@@ -1691,21 +1701,21 @@ var require_scan = __commonJS({
           if (opts.tokens) {
             tokens[tokens.length - 1].value = value;
             depth(tokens[tokens.length - 1]);
-            state.maxDepth += tokens[tokens.length - 1].depth;
+            state2.maxDepth += tokens[tokens.length - 1].depth;
           }
         }
-        state.slashes = slashes;
-        state.parts = parts;
+        state2.slashes = slashes;
+        state2.parts = parts;
       }
-      return state;
+      return state2;
     };
     module2.exports = scan;
   }
 });
 
-// node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/parse.js
+// ../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/parse.js
 var require_parse2 = __commonJS({
-  "node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/parse.js"(exports, module2) {
+  "../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/parse.js"(exports, module2) {
     "use strict";
     var constants = require_constants2();
     var utils = require_utils2();
@@ -1777,9 +1787,9 @@ var require_parse2 = __commonJS({
       parts.push(value);
       return parts;
     };
-    var isPlainBranch = (branch) => {
+    var isPlainBranch = (branch2) => {
       let escaped = false;
-      for (const ch of branch) {
+      for (const ch of branch2) {
         if (escaped === true) {
           escaped = false;
           continue;
@@ -1794,8 +1804,8 @@ var require_parse2 = __commonJS({
       }
       return true;
     };
-    var normalizeSimpleBranch = (branch) => {
-      let value = branch.trim();
+    var normalizeSimpleBranch = (branch2) => {
+      let value = branch2.trim();
       let changed = true;
       while (changed === true) {
         changed = false;
@@ -1882,29 +1892,29 @@ var require_parse2 = __commonJS({
       }
     };
     var getStarExtglobSequenceOutput = (pattern) => {
-      let index = 0;
+      let index2 = 0;
       const chars = [];
-      while (index < pattern.length) {
-        const match = parseRepeatedExtglob(pattern.slice(index), false);
+      while (index2 < pattern.length) {
+        const match = parseRepeatedExtglob(pattern.slice(index2), false);
         if (!match || match.type !== "*") {
           return;
         }
-        const branches = splitTopLevel(match.body).map((branch2) => branch2.trim());
+        const branches = splitTopLevel(match.body).map((branch3) => branch3.trim());
         if (branches.length !== 1) {
           return;
         }
-        const branch = normalizeSimpleBranch(branches[0]);
-        if (!branch || branch.length !== 1) {
+        const branch2 = normalizeSimpleBranch(branches[0]);
+        if (!branch2 || branch2.length !== 1) {
           return;
         }
-        chars.push(branch);
-        index += match.end + 1;
+        chars.push(branch2);
+        index2 += match.end + 1;
       }
       if (chars.length < 1) {
         return;
       }
-      const source = chars.length === 1 ? utils.escapeRegex(chars[0]) : `[${chars.map((ch) => utils.escapeRegex(ch)).join("")}]`;
-      return `${source}*`;
+      const source2 = chars.length === 1 ? utils.escapeRegex(chars[0]) : `[${chars.map((ch) => utils.escapeRegex(ch)).join("")}]`;
+      return `${source2}*`;
     };
     var repeatedExtglobRecursion = (pattern) => {
       let depth = 0;
@@ -1922,18 +1932,18 @@ var require_parse2 = __commonJS({
         return { risky: false };
       }
       const max = typeof options.maxExtglobRecursion === "number" ? options.maxExtglobRecursion : constants.DEFAULT_MAX_EXTGLOB_RECURSION;
-      const branches = splitTopLevel(body).map((branch) => branch.trim());
+      const branches = splitTopLevel(body).map((branch2) => branch2.trim());
       if (branches.length > 1) {
-        if (branches.some((branch) => branch === "") || branches.some((branch) => /^[*?]+$/.test(branch)) || hasRepeatedCharPrefixOverlap(branches)) {
+        if (branches.some((branch2) => branch2 === "") || branches.some((branch2) => /^[*?]+$/.test(branch2)) || hasRepeatedCharPrefixOverlap(branches)) {
           return { risky: true };
         }
       }
-      for (const branch of branches) {
-        const safeOutput = getStarExtglobSequenceOutput(branch);
+      for (const branch2 of branches) {
+        const safeOutput = getStarExtglobSequenceOutput(branch2);
         if (safeOutput) {
           return { risky: true, safeOutput };
         }
-        if (repeatedExtglobRecursion(branch) > max) {
+        if (repeatedExtglobRecursion(branch2) > max) {
           return { risky: true };
         }
       }
@@ -1952,7 +1962,7 @@ var require_parse2 = __commonJS({
       }
       const bos = { type: "bos", value: "", output: opts.prepend || "" };
       const tokens = [bos];
-      const capture = opts.capture ? "" : "?:";
+      const capture2 = opts.capture ? "" : "?:";
       const win32 = utils.isWindows(options);
       const PLATFORM_CHARS = constants.globChars(win32);
       const EXTGLOB_CHARS = constants.extglobChars(PLATFORM_CHARS);
@@ -1971,7 +1981,7 @@ var require_parse2 = __commonJS({
         START_ANCHOR
       } = PLATFORM_CHARS;
       const globstar = (opts2) => {
-        return `(${capture}(?:(?!${START_ANCHOR}${opts2.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+        return `(${capture2}(?:(?!${START_ANCHOR}${opts2.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
       };
       const nodot = opts.dot ? "" : NO_DOT;
       const qmarkNoDot = opts.dot ? QMARK : QMARK_NO_DOT;
@@ -1982,7 +1992,7 @@ var require_parse2 = __commonJS({
       if (typeof opts.noext === "boolean") {
         opts.noextglob = opts.noext;
       }
-      const state = {
+      const state2 = {
         input,
         index: -1,
         start: 0,
@@ -1999,63 +2009,63 @@ var require_parse2 = __commonJS({
         globstar: false,
         tokens
       };
-      input = utils.removePrefix(input, state);
+      input = utils.removePrefix(input, state2);
       len = input.length;
       const extglobs = [];
       const braces = [];
-      const stack = [];
+      const stack2 = [];
       let prev = bos;
       let value;
-      const eos = () => state.index === len - 1;
-      const peek = state.peek = (n = 1) => input[state.index + n];
-      const advance = state.advance = () => input[++state.index] || "";
-      const remaining = () => input.slice(state.index + 1);
+      const eos = () => state2.index === len - 1;
+      const peek = state2.peek = (n = 1) => input[state2.index + n];
+      const advance = state2.advance = () => input[++state2.index] || "";
+      const remaining = () => input.slice(state2.index + 1);
       const consume = (value2 = "", num = 0) => {
-        state.consumed += value2;
-        state.index += num;
+        state2.consumed += value2;
+        state2.index += num;
       };
-      const append = (token) => {
-        state.output += token.output != null ? token.output : token.value;
+      const append2 = (token) => {
+        state2.output += token.output != null ? token.output : token.value;
         consume(token.value);
       };
       const negate = () => {
         let count = 1;
         while (peek() === "!" && (peek(2) !== "(" || peek(3) === "?")) {
           advance();
-          state.start++;
+          state2.start++;
           count++;
         }
         if (count % 2 === 0) {
           return false;
         }
-        state.negated = true;
-        state.start++;
+        state2.negated = true;
+        state2.start++;
         return true;
       };
-      const increment = (type) => {
-        state[type]++;
-        stack.push(type);
+      const increment2 = (type) => {
+        state2[type]++;
+        stack2.push(type);
       };
       const decrement = (type) => {
-        state[type]--;
-        stack.pop();
+        state2[type]--;
+        stack2.pop();
       };
-      const push = (tok) => {
+      const push2 = (tok) => {
         if (prev.type === "globstar") {
-          const isBrace = state.braces > 0 && (tok.type === "comma" || tok.type === "brace");
+          const isBrace = state2.braces > 0 && (tok.type === "comma" || tok.type === "brace");
           const isExtglob = tok.extglob === true || extglobs.length && (tok.type === "pipe" || tok.type === "paren");
           if (tok.type !== "slash" && tok.type !== "paren" && !isBrace && !isExtglob) {
-            state.output = state.output.slice(0, -prev.output.length);
+            state2.output = state2.output.slice(0, -prev.output.length);
             prev.type = "star";
             prev.value = "*";
             prev.output = star;
-            state.output += prev.output;
+            state2.output += prev.output;
           }
         }
         if (extglobs.length && tok.type !== "paren") {
           extglobs[extglobs.length - 1].inner += tok.value;
         }
-        if (tok.value || tok.output) append(tok);
+        if (tok.value || tok.output) append2(tok);
         if (prev && prev.type === "text" && tok.type === "text") {
           prev.value += tok.value;
           prev.output = (prev.output || "") + tok.value;
@@ -2068,19 +2078,19 @@ var require_parse2 = __commonJS({
       const extglobOpen = (type, value2) => {
         const token = { ...EXTGLOB_CHARS[value2], conditions: 1, inner: "" };
         token.prev = prev;
-        token.parens = state.parens;
-        token.output = state.output;
-        token.startIndex = state.index;
+        token.parens = state2.parens;
+        token.output = state2.output;
+        token.startIndex = state2.index;
         token.tokensIndex = tokens.length;
         const output = (opts.capture ? "(" : "") + token.open;
-        increment("parens");
-        push({ type, value: value2, output: state.output ? "" : ONE_CHAR });
-        push({ type: "paren", extglob: true, value: advance(), output });
+        increment2("parens");
+        push2({ type, value: value2, output: state2.output ? "" : ONE_CHAR });
+        push2({ type: "paren", extglob: true, value: advance(), output });
         extglobs.push(token);
       };
       const extglobClose = (token) => {
-        const literal = input.slice(token.startIndex, state.index + 1);
-        const body = input.slice(token.startIndex + 2, state.index);
+        const literal = input.slice(token.startIndex, state2.index + 1);
+        const body = input.slice(token.startIndex + 2, state2.index);
         const analysis = analyzeRepeatedExtglob(body, opts);
         if ((token.type === "plus" || token.type === "star") && analysis.risky) {
           const safeOutput = analysis.safeOutput ? (token.output ? "" : ONE_CHAR) + (opts.capture ? `(${analysis.safeOutput})` : analysis.safeOutput) : void 0;
@@ -2093,9 +2103,9 @@ var require_parse2 = __commonJS({
             tokens[i].output = "";
             delete tokens[i].suffix;
           }
-          state.output = token.output + open.output;
-          state.backtrack = true;
-          push({ type: "paren", extglob: true, value, output: "" });
+          state2.output = token.output + open.output;
+          state2.backtrack = true;
+          push2({ type: "paren", extglob: true, value, output: "" });
           decrement("parens");
           return;
         }
@@ -2114,15 +2124,15 @@ var require_parse2 = __commonJS({
             output = token.close = `)${expression})${extglobStar})`;
           }
           if (token.prev.type === "bos") {
-            state.negatedExtglob = true;
+            state2.negatedExtglob = true;
           }
         }
-        push({ type: "paren", extglob: true, value, output });
+        push2({ type: "paren", extglob: true, value, output });
         decrement("parens");
       };
       if (opts.fastpaths !== false && !/(^[*!]|[/()[\]{}"])/.test(input)) {
         let backslashes = false;
-        let output = input.replace(REGEX_SPECIAL_CHARS_BACKREF, (m, esc, chars, first, rest, index) => {
+        let output = input.replace(REGEX_SPECIAL_CHARS_BACKREF, (m, esc, chars, first, rest, index2) => {
           if (first === "\\") {
             backslashes = true;
             return m;
@@ -2131,7 +2141,7 @@ var require_parse2 = __commonJS({
             if (esc) {
               return esc + first + (rest ? QMARK.repeat(rest.length) : "");
             }
-            if (index === 0) {
+            if (index2 === 0) {
               return qmarkNoDot + (rest ? QMARK.repeat(rest.length) : "");
             }
             return QMARK.repeat(chars.length);
@@ -2157,11 +2167,11 @@ var require_parse2 = __commonJS({
           }
         }
         if (output === input && opts.contains === true) {
-          state.output = input;
-          return state;
+          state2.output = input;
+          return state2;
         }
-        state.output = utils.wrapOutput(output, state, options);
-        return state;
+        state2.output = utils.wrapOutput(output, state2, options);
+        return state2;
       }
       while (!eos()) {
         value = advance();
@@ -2169,23 +2179,23 @@ var require_parse2 = __commonJS({
           continue;
         }
         if (value === "\\") {
-          const next = peek();
-          if (next === "/" && opts.bash !== true) {
+          const next2 = peek();
+          if (next2 === "/" && opts.bash !== true) {
             continue;
           }
-          if (next === "." || next === ";") {
+          if (next2 === "." || next2 === ";") {
             continue;
           }
-          if (!next) {
+          if (!next2) {
             value += "\\";
-            push({ type: "text", value });
+            push2({ type: "text", value });
             continue;
           }
           const match = /^\\+/.exec(remaining());
           let slashes = 0;
           if (match && match[0].length > 2) {
             slashes = match[0].length;
-            state.index += slashes;
+            state2.index += slashes;
             if (slashes % 2 !== 0) {
               value += "\\";
             }
@@ -2195,12 +2205,12 @@ var require_parse2 = __commonJS({
           } else {
             value += advance();
           }
-          if (state.brackets === 0) {
-            push({ type: "text", value });
+          if (state2.brackets === 0) {
+            push2({ type: "text", value });
             continue;
           }
         }
-        if (state.brackets > 0 && (value !== "]" || prev.value === "[" || prev.value === "[^")) {
+        if (state2.brackets > 0 && (value !== "]" || prev.value === "[" || prev.value === "[^")) {
           if (opts.posix !== false && value === ":") {
             const inner = prev.value.slice(1);
             if (inner.includes("[")) {
@@ -2212,7 +2222,7 @@ var require_parse2 = __commonJS({
                 const posix = POSIX_REGEX_SOURCE[rest2];
                 if (posix) {
                   prev.value = pre + posix;
-                  state.backtrack = true;
+                  state2.backtrack = true;
                   advance();
                   if (!bos.output && tokens.indexOf(prev) === 1) {
                     bos.output = ONE_CHAR;
@@ -2232,37 +2242,37 @@ var require_parse2 = __commonJS({
             value = "^";
           }
           prev.value += value;
-          append({ value });
+          append2({ value });
           continue;
         }
-        if (state.quotes === 1 && value !== '"') {
+        if (state2.quotes === 1 && value !== '"') {
           value = utils.escapeRegex(value);
           prev.value += value;
-          append({ value });
+          append2({ value });
           continue;
         }
         if (value === '"') {
-          state.quotes = state.quotes === 1 ? 0 : 1;
+          state2.quotes = state2.quotes === 1 ? 0 : 1;
           if (opts.keepQuotes === true) {
-            push({ type: "text", value });
+            push2({ type: "text", value });
           }
           continue;
         }
         if (value === "(") {
-          increment("parens");
-          push({ type: "paren", value });
+          increment2("parens");
+          push2({ type: "paren", value });
           continue;
         }
         if (value === ")") {
-          if (state.parens === 0 && opts.strictBrackets === true) {
+          if (state2.parens === 0 && opts.strictBrackets === true) {
             throw new SyntaxError(syntaxError("opening", "("));
           }
           const extglob = extglobs[extglobs.length - 1];
-          if (extglob && state.parens === extglob.parens + 1) {
+          if (extglob && state2.parens === extglob.parens + 1) {
             extglobClose(extglobs.pop());
             continue;
           }
-          push({ type: "paren", value, output: state.parens ? ")" : "\\)" });
+          push2({ type: "paren", value, output: state2.parens ? ")" : "\\)" });
           decrement("parens");
           continue;
         }
@@ -2273,21 +2283,21 @@ var require_parse2 = __commonJS({
             }
             value = `\\${value}`;
           } else {
-            increment("brackets");
+            increment2("brackets");
           }
-          push({ type: "bracket", value });
+          push2({ type: "bracket", value });
           continue;
         }
         if (value === "]") {
           if (opts.nobracket === true || prev && prev.type === "bracket" && prev.value.length === 1) {
-            push({ type: "text", value, output: `\\${value}` });
+            push2({ type: "text", value, output: `\\${value}` });
             continue;
           }
-          if (state.brackets === 0) {
+          if (state2.brackets === 0) {
             if (opts.strictBrackets === true) {
               throw new SyntaxError(syntaxError("opening", "["));
             }
-            push({ type: "text", value, output: `\\${value}` });
+            push2({ type: "text", value, output: `\\${value}` });
             continue;
           }
           decrement("brackets");
@@ -2296,38 +2306,38 @@ var require_parse2 = __commonJS({
             value = `/${value}`;
           }
           prev.value += value;
-          append({ value });
+          append2({ value });
           if (opts.literalBrackets === false || utils.hasRegexChars(prevValue)) {
             continue;
           }
           const escaped = utils.escapeRegex(prev.value);
-          state.output = state.output.slice(0, -prev.value.length);
+          state2.output = state2.output.slice(0, -prev.value.length);
           if (opts.literalBrackets === true) {
-            state.output += escaped;
+            state2.output += escaped;
             prev.value = escaped;
             continue;
           }
-          prev.value = `(${capture}${escaped}|${prev.value})`;
-          state.output += prev.value;
+          prev.value = `(${capture2}${escaped}|${prev.value})`;
+          state2.output += prev.value;
           continue;
         }
         if (value === "{" && opts.nobrace !== true) {
-          increment("braces");
+          increment2("braces");
           const open = {
             type: "brace",
             value,
             output: "(",
-            outputIndex: state.output.length,
-            tokensIndex: state.tokens.length
+            outputIndex: state2.output.length,
+            tokensIndex: state2.tokens.length
           };
           braces.push(open);
-          push(open);
+          push2(open);
           continue;
         }
         if (value === "}") {
           const brace = braces[braces.length - 1];
           if (opts.nobrace === true || !brace) {
-            push({ type: "text", value, output: value });
+            push2({ type: "text", value, output: value });
             continue;
           }
           let output = ")";
@@ -2344,19 +2354,19 @@ var require_parse2 = __commonJS({
               }
             }
             output = expandRange(range, opts);
-            state.backtrack = true;
+            state2.backtrack = true;
           }
           if (brace.comma !== true && brace.dots !== true) {
-            const out = state.output.slice(0, brace.outputIndex);
-            const toks = state.tokens.slice(brace.tokensIndex);
+            const out = state2.output.slice(0, brace.outputIndex);
+            const toks = state2.tokens.slice(brace.tokensIndex);
             brace.value = brace.output = "\\{";
             value = output = "\\}";
-            state.output = out;
+            state2.output = out;
             for (const t of toks) {
-              state.output += t.output || t.value;
+              state2.output += t.output || t.value;
             }
           }
-          push({ type: "brace", value, output });
+          push2({ type: "brace", value, output });
           decrement("braces");
           braces.pop();
           continue;
@@ -2365,33 +2375,33 @@ var require_parse2 = __commonJS({
           if (extglobs.length > 0) {
             extglobs[extglobs.length - 1].conditions++;
           }
-          push({ type: "text", value });
+          push2({ type: "text", value });
           continue;
         }
         if (value === ",") {
           let output = value;
           const brace = braces[braces.length - 1];
-          if (brace && stack[stack.length - 1] === "braces") {
+          if (brace && stack2[stack2.length - 1] === "braces") {
             brace.comma = true;
             output = "|";
           }
-          push({ type: "comma", value, output });
+          push2({ type: "comma", value, output });
           continue;
         }
         if (value === "/") {
-          if (prev.type === "dot" && state.index === state.start + 1) {
-            state.start = state.index + 1;
-            state.consumed = "";
-            state.output = "";
+          if (prev.type === "dot" && state2.index === state2.start + 1) {
+            state2.start = state2.index + 1;
+            state2.consumed = "";
+            state2.output = "";
             tokens.pop();
             prev = bos;
             continue;
           }
-          push({ type: "slash", value, output: SLASH_LITERAL });
+          push2({ type: "slash", value, output: SLASH_LITERAL });
           continue;
         }
         if (value === ".") {
-          if (state.braces > 0 && prev.type === "dot") {
+          if (state2.braces > 0 && prev.type === "dot") {
             if (prev.value === ".") prev.output = DOT_LITERAL;
             const brace = braces[braces.length - 1];
             prev.type = "dots";
@@ -2400,11 +2410,11 @@ var require_parse2 = __commonJS({
             brace.dots = true;
             continue;
           }
-          if (state.braces + state.parens === 0 && prev.type !== "bos" && prev.type !== "slash") {
-            push({ type: "text", value, output: DOT_LITERAL });
+          if (state2.braces + state2.parens === 0 && prev.type !== "bos" && prev.type !== "slash") {
+            push2({ type: "text", value, output: DOT_LITERAL });
             continue;
           }
-          push({ type: "dot", value, output: DOT_LITERAL });
+          push2({ type: "dot", value, output: DOT_LITERAL });
           continue;
         }
         if (value === "?") {
@@ -2414,22 +2424,22 @@ var require_parse2 = __commonJS({
             continue;
           }
           if (prev && prev.type === "paren") {
-            const next = peek();
+            const next2 = peek();
             let output = value;
-            if (next === "<" && !utils.supportsLookbehinds()) {
+            if (next2 === "<" && !utils.supportsLookbehinds()) {
               throw new Error("Node.js v10 or higher is required for regex lookbehinds");
             }
-            if (prev.value === "(" && !/[!=<:]/.test(next) || next === "<" && !/<([!=]|\w+>)/.test(remaining())) {
+            if (prev.value === "(" && !/[!=<:]/.test(next2) || next2 === "<" && !/<([!=]|\w+>)/.test(remaining())) {
               output = `\\${value}`;
             }
-            push({ type: "text", value, output });
+            push2({ type: "text", value, output });
             continue;
           }
           if (opts.dot !== true && (prev.type === "slash" || prev.type === "bos")) {
-            push({ type: "qmark", value, output: QMARK_NO_DOT });
+            push2({ type: "qmark", value, output: QMARK_NO_DOT });
             continue;
           }
-          push({ type: "qmark", value, output: QMARK });
+          push2({ type: "qmark", value, output: QMARK });
           continue;
         }
         if (value === "!") {
@@ -2439,7 +2449,7 @@ var require_parse2 = __commonJS({
               continue;
             }
           }
-          if (opts.nonegate !== true && state.index === 0) {
+          if (opts.nonegate !== true && state2.index === 0) {
             negate();
             continue;
           }
@@ -2450,22 +2460,22 @@ var require_parse2 = __commonJS({
             continue;
           }
           if (prev && prev.value === "(" || opts.regex === false) {
-            push({ type: "plus", value, output: PLUS_LITERAL });
+            push2({ type: "plus", value, output: PLUS_LITERAL });
             continue;
           }
-          if (prev && (prev.type === "bracket" || prev.type === "paren" || prev.type === "brace") || state.parens > 0) {
-            push({ type: "plus", value });
+          if (prev && (prev.type === "bracket" || prev.type === "paren" || prev.type === "brace") || state2.parens > 0) {
+            push2({ type: "plus", value });
             continue;
           }
-          push({ type: "plus", value: PLUS_LITERAL });
+          push2({ type: "plus", value: PLUS_LITERAL });
           continue;
         }
         if (value === "@") {
           if (opts.noextglob !== true && peek() === "(" && peek(2) !== "?") {
-            push({ type: "at", extglob: true, value, output: "" });
+            push2({ type: "at", extglob: true, value, output: "" });
             continue;
           }
-          push({ type: "text", value });
+          push2({ type: "text", value });
           continue;
         }
         if (value !== "*") {
@@ -2475,9 +2485,9 @@ var require_parse2 = __commonJS({
           const match = REGEX_NON_SPECIAL_CHARS.exec(remaining());
           if (match) {
             value += match[0];
-            state.index += match[0].length;
+            state2.index += match[0].length;
           }
-          push({ type: "text", value });
+          push2({ type: "text", value });
           continue;
         }
         if (prev && (prev.type === "globstar" || prev.star === true)) {
@@ -2485,8 +2495,8 @@ var require_parse2 = __commonJS({
           prev.star = true;
           prev.value += value;
           prev.output = star;
-          state.backtrack = true;
-          state.globstar = true;
+          state2.backtrack = true;
+          state2.globstar = true;
           consume(value);
           continue;
         }
@@ -2505,17 +2515,17 @@ var require_parse2 = __commonJS({
           const isStart = prior.type === "slash" || prior.type === "bos";
           const afterStar = before && (before.type === "star" || before.type === "globstar");
           if (opts.bash === true && (!isStart || rest[0] && rest[0] !== "/")) {
-            push({ type: "star", value, output: "" });
+            push2({ type: "star", value, output: "" });
             continue;
           }
-          const isBrace = state.braces > 0 && (prior.type === "comma" || prior.type === "brace");
+          const isBrace = state2.braces > 0 && (prior.type === "comma" || prior.type === "brace");
           const isExtglob = extglobs.length && (prior.type === "pipe" || prior.type === "paren");
           if (!isStart && prior.type !== "paren" && !isBrace && !isExtglob) {
-            push({ type: "star", value, output: "" });
+            push2({ type: "star", value, output: "" });
             continue;
           }
           while (rest.slice(0, 3) === "/**") {
-            const after = input[state.index + 4];
+            const after = input[state2.index + 4];
             if (after && after !== "/") {
               break;
             }
@@ -2526,51 +2536,51 @@ var require_parse2 = __commonJS({
             prev.type = "globstar";
             prev.value += value;
             prev.output = globstar(opts);
-            state.output = prev.output;
-            state.globstar = true;
+            state2.output = prev.output;
+            state2.globstar = true;
             consume(value);
             continue;
           }
           if (prior.type === "slash" && prior.prev.type !== "bos" && !afterStar && eos()) {
-            state.output = state.output.slice(0, -(prior.output + prev.output).length);
+            state2.output = state2.output.slice(0, -(prior.output + prev.output).length);
             prior.output = `(?:${prior.output}`;
             prev.type = "globstar";
             prev.output = globstar(opts) + (opts.strictSlashes ? ")" : "|$)");
             prev.value += value;
-            state.globstar = true;
-            state.output += prior.output + prev.output;
+            state2.globstar = true;
+            state2.output += prior.output + prev.output;
             consume(value);
             continue;
           }
           if (prior.type === "slash" && prior.prev.type !== "bos" && rest[0] === "/") {
             const end = rest[1] !== void 0 ? "|$" : "";
-            state.output = state.output.slice(0, -(prior.output + prev.output).length);
+            state2.output = state2.output.slice(0, -(prior.output + prev.output).length);
             prior.output = `(?:${prior.output}`;
             prev.type = "globstar";
             prev.output = `${globstar(opts)}${SLASH_LITERAL}|${SLASH_LITERAL}${end})`;
             prev.value += value;
-            state.output += prior.output + prev.output;
-            state.globstar = true;
+            state2.output += prior.output + prev.output;
+            state2.globstar = true;
             consume(value + advance());
-            push({ type: "slash", value: "/", output: "" });
+            push2({ type: "slash", value: "/", output: "" });
             continue;
           }
           if (prior.type === "bos" && rest[0] === "/") {
             prev.type = "globstar";
             prev.value += value;
             prev.output = `(?:^|${SLASH_LITERAL}|${globstar(opts)}${SLASH_LITERAL})`;
-            state.output = prev.output;
-            state.globstar = true;
+            state2.output = prev.output;
+            state2.globstar = true;
             consume(value + advance());
-            push({ type: "slash", value: "/", output: "" });
+            push2({ type: "slash", value: "/", output: "" });
             continue;
           }
-          state.output = state.output.slice(0, -prev.output.length);
+          state2.output = state2.output.slice(0, -prev.output.length);
           prev.type = "globstar";
           prev.output = globstar(opts);
           prev.value += value;
-          state.output += prev.output;
-          state.globstar = true;
+          state2.output += prev.output;
+          state2.globstar = true;
           consume(value);
           continue;
         }
@@ -2580,60 +2590,60 @@ var require_parse2 = __commonJS({
           if (prev.type === "bos" || prev.type === "slash") {
             token.output = nodot + token.output;
           }
-          push(token);
+          push2(token);
           continue;
         }
         if (prev && (prev.type === "bracket" || prev.type === "paren") && opts.regex === true) {
           token.output = value;
-          push(token);
+          push2(token);
           continue;
         }
-        if (state.index === state.start || prev.type === "slash" || prev.type === "dot") {
+        if (state2.index === state2.start || prev.type === "slash" || prev.type === "dot") {
           if (prev.type === "dot") {
-            state.output += NO_DOT_SLASH;
+            state2.output += NO_DOT_SLASH;
             prev.output += NO_DOT_SLASH;
           } else if (opts.dot === true) {
-            state.output += NO_DOTS_SLASH;
+            state2.output += NO_DOTS_SLASH;
             prev.output += NO_DOTS_SLASH;
           } else {
-            state.output += nodot;
+            state2.output += nodot;
             prev.output += nodot;
           }
           if (peek() !== "*") {
-            state.output += ONE_CHAR;
+            state2.output += ONE_CHAR;
             prev.output += ONE_CHAR;
           }
         }
-        push(token);
+        push2(token);
       }
-      while (state.brackets > 0) {
+      while (state2.brackets > 0) {
         if (opts.strictBrackets === true) throw new SyntaxError(syntaxError("closing", "]"));
-        state.output = utils.escapeLast(state.output, "[");
+        state2.output = utils.escapeLast(state2.output, "[");
         decrement("brackets");
       }
-      while (state.parens > 0) {
+      while (state2.parens > 0) {
         if (opts.strictBrackets === true) throw new SyntaxError(syntaxError("closing", ")"));
-        state.output = utils.escapeLast(state.output, "(");
+        state2.output = utils.escapeLast(state2.output, "(");
         decrement("parens");
       }
-      while (state.braces > 0) {
+      while (state2.braces > 0) {
         if (opts.strictBrackets === true) throw new SyntaxError(syntaxError("closing", "}"));
-        state.output = utils.escapeLast(state.output, "{");
+        state2.output = utils.escapeLast(state2.output, "{");
         decrement("braces");
       }
       if (opts.strictSlashes !== true && (prev.type === "star" || prev.type === "bracket")) {
-        push({ type: "maybe_slash", value: "", output: `${SLASH_LITERAL}?` });
+        push2({ type: "maybe_slash", value: "", output: `${SLASH_LITERAL}?` });
       }
-      if (state.backtrack === true) {
-        state.output = "";
-        for (const token of state.tokens) {
-          state.output += token.output != null ? token.output : token.value;
+      if (state2.backtrack === true) {
+        state2.output = "";
+        for (const token of state2.tokens) {
+          state2.output += token.output != null ? token.output : token.value;
           if (token.suffix) {
-            state.output += token.suffix;
+            state2.output += token.suffix;
           }
         }
       }
-      return state;
+      return state2;
     };
     parse.fastpaths = (input, options) => {
       const opts = { ...options };
@@ -2657,15 +2667,15 @@ var require_parse2 = __commonJS({
       } = constants.globChars(win32);
       const nodot = opts.dot ? NO_DOTS : NO_DOT;
       const slashDot = opts.dot ? NO_DOTS_SLASH : NO_DOT;
-      const capture = opts.capture ? "" : "?:";
-      const state = { negated: false, prefix: "" };
+      const capture2 = opts.capture ? "" : "?:";
+      const state2 = { negated: false, prefix: "" };
       let star = opts.bash === true ? ".*?" : STAR;
       if (opts.capture) {
         star = `(${star})`;
       }
       const globstar = (opts2) => {
         if (opts2.noglobstar === true) return star;
-        return `(${capture}(?:(?!${START_ANCHOR}${opts2.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+        return `(${capture2}(?:(?!${START_ANCHOR}${opts2.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
       };
       const create = (str) => {
         switch (str) {
@@ -2688,26 +2698,26 @@ var require_parse2 = __commonJS({
           default: {
             const match = /^(.*?)\.(\w+)$/.exec(str);
             if (!match) return;
-            const source2 = create(match[1]);
-            if (!source2) return;
-            return source2 + DOT_LITERAL + match[2];
+            const source3 = create(match[1]);
+            if (!source3) return;
+            return source3 + DOT_LITERAL + match[2];
           }
         }
       };
-      const output = utils.removePrefix(input, state);
-      let source = create(output);
-      if (source && opts.strictSlashes !== true) {
-        source += `${SLASH_LITERAL}?`;
+      const output = utils.removePrefix(input, state2);
+      let source2 = create(output);
+      if (source2 && opts.strictSlashes !== true) {
+        source2 += `${SLASH_LITERAL}?`;
       }
-      return source;
+      return source2;
     };
     module2.exports = parse;
   }
 });
 
-// node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/picomatch.js
+// ../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/picomatch.js
 var require_picomatch = __commonJS({
-  "node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/picomatch.js"(exports, module2) {
+  "../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/lib/picomatch.js"(exports, module2) {
     "use strict";
     var path = require("path");
     var scan = require_scan();
@@ -2720,8 +2730,8 @@ var require_picomatch = __commonJS({
         const fns = glob.map((input) => picomatch(input, options, returnState));
         const arrayMatcher = (str) => {
           for (const isMatch of fns) {
-            const state2 = isMatch(str);
-            if (state2) return state2;
+            const state3 = isMatch(str);
+            if (state3) return state3;
           }
           return false;
         };
@@ -2734,7 +2744,7 @@ var require_picomatch = __commonJS({
       const opts = options || {};
       const posix = utils.isWindows(options);
       const regex = isState ? picomatch.compileRe(glob, options) : picomatch.makeRe(glob, options, false, true);
-      const state = regex.state;
+      const state2 = regex.state;
       delete regex.state;
       let isIgnored = () => false;
       if (opts.ignore) {
@@ -2743,7 +2753,7 @@ var require_picomatch = __commonJS({
       }
       const matcher = (input, returnObject = false) => {
         const { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix });
-        const result = { glob, state, regex, posix, input, output, match, isMatch };
+        const result = { glob, state: state2, regex, posix, input, output, match, isMatch };
         if (typeof opts.onResult === "function") {
           opts.onResult(result);
         }
@@ -2764,7 +2774,7 @@ var require_picomatch = __commonJS({
         return returnObject ? result : true;
       };
       if (returnState) {
-        matcher.state = state;
+        matcher.state = state2;
       }
       return matcher;
     };
@@ -2802,20 +2812,20 @@ var require_picomatch = __commonJS({
       return parse(pattern, { ...options, fastpaths: false });
     };
     picomatch.scan = (input, options) => scan(input, options);
-    picomatch.compileRe = (state, options, returnOutput = false, returnState = false) => {
+    picomatch.compileRe = (state2, options, returnOutput = false, returnState = false) => {
       if (returnOutput === true) {
-        return state.output;
+        return state2.output;
       }
       const opts = options || {};
       const prepend = opts.contains ? "" : "^";
-      const append = opts.contains ? "" : "$";
-      let source = `${prepend}(?:${state.output})${append}`;
-      if (state && state.negated === true) {
-        source = `^(?!${source}).*$`;
+      const append2 = opts.contains ? "" : "$";
+      let source2 = `${prepend}(?:${state2.output})${append2}`;
+      if (state2 && state2.negated === true) {
+        source2 = `^(?!${source2}).*$`;
       }
-      const regex = picomatch.toRegex(source, options);
+      const regex = picomatch.toRegex(source2, options);
       if (returnState === true) {
-        regex.state = state;
+        regex.state = state2;
       }
       return regex;
     };
@@ -2832,10 +2842,10 @@ var require_picomatch = __commonJS({
       }
       return picomatch.compileRe(parsed, options, returnOutput, returnState);
     };
-    picomatch.toRegex = (source, options) => {
+    picomatch.toRegex = (source2, options) => {
       try {
         const opts = options || {};
-        return new RegExp(source, opts.flags || (opts.nocase ? "i" : ""));
+        return new RegExp(source2, opts.flags || (opts.nocase ? "i" : ""));
       } catch (err) {
         if (options && options.debug === true) throw err;
         return /$^/;
@@ -2846,17 +2856,17 @@ var require_picomatch = __commonJS({
   }
 });
 
-// node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/index.js
+// ../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/index.js
 var require_picomatch2 = __commonJS({
-  "node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/index.js"(exports, module2) {
+  "../../../node_modules/.pnpm/picomatch@2.3.2/node_modules/picomatch/index.js"(exports, module2) {
     "use strict";
     module2.exports = require_picomatch();
   }
 });
 
-// node_modules/.pnpm/micromatch@4.0.8/node_modules/micromatch/index.js
+// ../../../node_modules/.pnpm/micromatch@4.0.8/node_modules/micromatch/index.js
 var require_micromatch = __commonJS({
-  "node_modules/.pnpm/micromatch@4.0.8/node_modules/micromatch/index.js"(exports, module2) {
+  "../../../node_modules/.pnpm/micromatch@4.0.8/node_modules/micromatch/index.js"(exports, module2) {
     "use strict";
     var util = require("util");
     var braces = require_braces();
@@ -2864,8 +2874,8 @@ var require_micromatch = __commonJS({
     var utils = require_utils2();
     var isEmptyString = (v) => v === "" || v === "./";
     var hasBraces = (v) => {
-      const index = v.indexOf("{");
-      return index > -1 && v.indexOf("}", index) > -1;
+      const index2 = v.indexOf("{");
+      return index2 > -1 && v.indexOf("}", index2) > -1;
     };
     var micromatch2 = (list, patterns, options) => {
       patterns = [].concat(patterns);
@@ -2874,10 +2884,10 @@ var require_micromatch = __commonJS({
       let keep = /* @__PURE__ */ new Set();
       let items = /* @__PURE__ */ new Set();
       let negatives = 0;
-      let onResult = (state) => {
-        items.add(state.output);
+      let onResult = (state2) => {
+        items.add(state2.output);
         if (options && options.onResult) {
-          options.onResult(state);
+          options.onResult(state2);
         }
       };
       for (let i = 0; i < patterns.length; i++) {
@@ -2916,9 +2926,9 @@ var require_micromatch = __commonJS({
       patterns = [].concat(patterns).map(String);
       let result = /* @__PURE__ */ new Set();
       let items = [];
-      let onResult = (state) => {
-        if (options.onResult) options.onResult(state);
-        items.push(state.output);
+      let onResult = (state2) => {
+        if (options.onResult) options.onResult(state2);
+        items.push(state2.output);
       };
       let matches = new Set(micromatch2(list, patterns, { ...options, onResult }));
       for (let item of items) {
@@ -2951,7 +2961,7 @@ var require_micromatch = __commonJS({
       }
       let keys = micromatch2(Object.keys(obj), patterns, options);
       let res = {};
-      for (let key of keys) res[key] = obj[key];
+      for (let key2 of keys) res[key2] = obj[key2];
       return res;
     };
     micromatch2.some = (list, patterns, options) => {
@@ -3021,6 +3031,5271 @@ __export(main_exports, {
   default: () => MdbasePlugin
 });
 module.exports = __toCommonJS(main_exports);
+
+// ../../../node_modules/.pnpm/esm-env@1.2.2/node_modules/esm-env/dev-fallback.js
+var _a, _b;
+var node_env = (_b = (_a = globalThis.process) == null ? void 0 : _a.env) == null ? void 0 : _b.NODE_ENV;
+var dev_fallback_default = node_env && !node_env.toLowerCase().startsWith("prod");
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/shared/utils.js
+var is_array = Array.isArray;
+var index_of = Array.prototype.indexOf;
+var includes = Array.prototype.includes;
+var array_from = Array.from;
+var object_keys = Object.keys;
+var define_property = Object.defineProperty;
+var get_descriptor = Object.getOwnPropertyDescriptor;
+var object_prototype = Object.prototype;
+var array_prototype = Array.prototype;
+var get_prototype_of = Object.getPrototypeOf;
+var is_extensible = Object.isExtensible;
+var noop = () => {
+};
+function run_all(arr) {
+  for (var i = 0; i < arr.length; i++) {
+    arr[i]();
+  }
+}
+function deferred() {
+  var resolve;
+  var reject;
+  var promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/constants.js
+var DERIVED = 1 << 1;
+var EFFECT = 1 << 2;
+var RENDER_EFFECT = 1 << 3;
+var MANAGED_EFFECT = 1 << 24;
+var BLOCK_EFFECT = 1 << 4;
+var BRANCH_EFFECT = 1 << 5;
+var ROOT_EFFECT = 1 << 6;
+var BOUNDARY_EFFECT = 1 << 7;
+var CONNECTED = 1 << 9;
+var CLEAN = 1 << 10;
+var DIRTY = 1 << 11;
+var MAYBE_DIRTY = 1 << 12;
+var INERT = 1 << 13;
+var DESTROYED = 1 << 14;
+var REACTION_RAN = 1 << 15;
+var DESTROYING = 1 << 25;
+var EFFECT_TRANSPARENT = 1 << 16;
+var EAGER_EFFECT = 1 << 17;
+var HEAD_EFFECT = 1 << 18;
+var EFFECT_PRESERVED = 1 << 19;
+var USER_EFFECT = 1 << 20;
+var EFFECT_OFFSCREEN = 1 << 25;
+var WAS_MARKED = 1 << 16;
+var REACTION_IS_UPDATING = 1 << 21;
+var ASYNC = 1 << 22;
+var ERROR_VALUE = 1 << 23;
+var STATE_SYMBOL = Symbol("$state");
+var LEGACY_PROPS = Symbol("legacy props");
+var LOADING_ATTR_SYMBOL = Symbol("");
+var PROXY_PATH_SYMBOL = Symbol("proxy path");
+var HMR_ANCHOR = Symbol("hmr anchor");
+var STALE_REACTION = new class StaleReactionError extends Error {
+  constructor() {
+    super(...arguments);
+    __publicField(this, "name", "StaleReactionError");
+    __publicField(this, "message", "The reaction that called `getAbortSignal()` was re-run or destroyed");
+  }
+}();
+var _a2;
+var IS_XHTML = (
+  // We gotta write it like this because after downleveling the pure comment may end up in the wrong location
+  !!((_a2 = globalThis.document) == null ? void 0 : _a2.contentType) && /* @__PURE__ */ globalThis.document.contentType.includes("xml")
+);
+var TEXT_NODE = 3;
+var COMMENT_NODE = 8;
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/shared/errors.js
+function invariant_violation(message) {
+  if (dev_fallback_default) {
+    const error = new Error(`invariant_violation
+An invariant violation occurred, meaning Svelte's internal assumptions were flawed. This is a bug in Svelte, not your app \u2014 please open an issue at https://github.com/sveltejs/svelte, citing the following message: "${message}"
+https://svelte.dev/e/invariant_violation`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/invariant_violation`);
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/errors.js
+function async_derived_orphan() {
+  if (dev_fallback_default) {
+    const error = new Error(`async_derived_orphan
+Cannot create a \`$derived(...)\` with an \`await\` expression outside of an effect tree
+https://svelte.dev/e/async_derived_orphan`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/async_derived_orphan`);
+  }
+}
+function derived_references_self() {
+  if (dev_fallback_default) {
+    const error = new Error(`derived_references_self
+A derived value cannot reference itself recursively
+https://svelte.dev/e/derived_references_self`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/derived_references_self`);
+  }
+}
+function each_key_duplicate(a, b, value) {
+  if (dev_fallback_default) {
+    const error = new Error(`each_key_duplicate
+${value ? `Keyed each block has duplicate key \`${value}\` at indexes ${a} and ${b}` : `Keyed each block has duplicate key at indexes ${a} and ${b}`}
+https://svelte.dev/e/each_key_duplicate`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/each_key_duplicate`);
+  }
+}
+function each_key_volatile(index2, a, b) {
+  if (dev_fallback_default) {
+    const error = new Error(`each_key_volatile
+Keyed each block has key that is not idempotent \u2014 the key for item at index ${index2} was \`${a}\` but is now \`${b}\`. Keys must be the same each time for a given item
+https://svelte.dev/e/each_key_volatile`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/each_key_volatile`);
+  }
+}
+function effect_update_depth_exceeded() {
+  if (dev_fallback_default) {
+    const error = new Error(`effect_update_depth_exceeded
+Maximum update depth exceeded. This typically indicates that an effect reads and writes the same piece of state
+https://svelte.dev/e/effect_update_depth_exceeded`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/effect_update_depth_exceeded`);
+  }
+}
+function hydration_failed() {
+  if (dev_fallback_default) {
+    const error = new Error(`hydration_failed
+Failed to hydrate the application
+https://svelte.dev/e/hydration_failed`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/hydration_failed`);
+  }
+}
+function rune_outside_svelte(rune) {
+  if (dev_fallback_default) {
+    const error = new Error(`rune_outside_svelte
+The \`${rune}\` rune is only available inside \`.svelte\` and \`.svelte.js/ts\` files
+https://svelte.dev/e/rune_outside_svelte`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/rune_outside_svelte`);
+  }
+}
+function state_descriptors_fixed() {
+  if (dev_fallback_default) {
+    const error = new Error(`state_descriptors_fixed
+Property descriptors defined on \`$state\` objects must contain \`value\` and always be \`enumerable\`, \`configurable\` and \`writable\`.
+https://svelte.dev/e/state_descriptors_fixed`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/state_descriptors_fixed`);
+  }
+}
+function state_prototype_fixed() {
+  if (dev_fallback_default) {
+    const error = new Error(`state_prototype_fixed
+Cannot set prototype of \`$state\` object
+https://svelte.dev/e/state_prototype_fixed`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/state_prototype_fixed`);
+  }
+}
+function state_unsafe_mutation() {
+  if (dev_fallback_default) {
+    const error = new Error(`state_unsafe_mutation
+Updating state inside \`$derived(...)\`, \`$inspect(...)\` or a template expression is forbidden. If the value should not be reactive, declare it without \`$state\`
+https://svelte.dev/e/state_unsafe_mutation`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/state_unsafe_mutation`);
+  }
+}
+function svelte_boundary_reset_onerror() {
+  if (dev_fallback_default) {
+    const error = new Error(`svelte_boundary_reset_onerror
+A \`<svelte:boundary>\` \`reset\` function cannot be called while an error is still being handled
+https://svelte.dev/e/svelte_boundary_reset_onerror`);
+    error.name = "Svelte error";
+    throw error;
+  } else {
+    throw new Error(`https://svelte.dev/e/svelte_boundary_reset_onerror`);
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/constants.js
+var EACH_ITEM_REACTIVE = 1;
+var EACH_INDEX_REACTIVE = 1 << 1;
+var EACH_IS_CONTROLLED = 1 << 2;
+var EACH_IS_ANIMATED = 1 << 3;
+var EACH_ITEM_IMMUTABLE = 1 << 4;
+var PROPS_IS_RUNES = 1 << 1;
+var PROPS_IS_UPDATED = 1 << 2;
+var PROPS_IS_BINDABLE = 1 << 3;
+var PROPS_IS_LAZY_INITIAL = 1 << 4;
+var TRANSITION_OUT = 1 << 1;
+var TRANSITION_GLOBAL = 1 << 2;
+var TEMPLATE_FRAGMENT = 1;
+var TEMPLATE_USE_IMPORT_NODE = 1 << 1;
+var TEMPLATE_USE_SVG = 1 << 2;
+var TEMPLATE_USE_MATHML = 1 << 3;
+var HYDRATION_START = "[";
+var HYDRATION_START_ELSE = "[!";
+var HYDRATION_START_FAILED = "[?";
+var HYDRATION_END = "]";
+var HYDRATION_ERROR = {};
+var ELEMENT_PRESERVE_ATTRIBUTE_CASE = 1 << 1;
+var ELEMENT_IS_INPUT = 1 << 2;
+var UNINITIALIZED = Symbol();
+var FILENAME = Symbol("filename");
+var HMR = Symbol("hmr");
+var NAMESPACE_HTML = "http://www.w3.org/1999/xhtml";
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/warnings.js
+var bold = "font-weight: bold";
+var normal = "font-weight: normal";
+function await_reactivity_loss(name) {
+  if (dev_fallback_default) {
+    console.warn(`%c[svelte] await_reactivity_loss
+%cDetected reactivity loss when reading \`${name}\`. This happens when state is read in an async function after an earlier \`await\`
+https://svelte.dev/e/await_reactivity_loss`, bold, normal);
+  } else {
+    console.warn(`https://svelte.dev/e/await_reactivity_loss`);
+  }
+}
+function await_waterfall(name, location) {
+  if (dev_fallback_default) {
+    console.warn(`%c[svelte] await_waterfall
+%cAn async derived, \`${name}\` (${location}) was not read immediately after it resolved. This often indicates an unnecessary waterfall, which can slow down your app
+https://svelte.dev/e/await_waterfall`, bold, normal);
+  } else {
+    console.warn(`https://svelte.dev/e/await_waterfall`);
+  }
+}
+function derived_inert() {
+  if (dev_fallback_default) {
+    console.warn(`%c[svelte] derived_inert
+%cReading a derived belonging to a now-destroyed effect may result in stale values
+https://svelte.dev/e/derived_inert`, bold, normal);
+  } else {
+    console.warn(`https://svelte.dev/e/derived_inert`);
+  }
+}
+function hydration_mismatch(location) {
+  if (dev_fallback_default) {
+    console.warn(
+      `%c[svelte] hydration_mismatch
+%c${location ? `Hydration failed because the initial UI does not match what was rendered on the server. The error occurred near ${location}` : "Hydration failed because the initial UI does not match what was rendered on the server"}
+https://svelte.dev/e/hydration_mismatch`,
+      bold,
+      normal
+    );
+  } else {
+    console.warn(`https://svelte.dev/e/hydration_mismatch`);
+  }
+}
+function lifecycle_double_unmount() {
+  if (dev_fallback_default) {
+    console.warn(`%c[svelte] lifecycle_double_unmount
+%cTried to unmount a component that was not mounted
+https://svelte.dev/e/lifecycle_double_unmount`, bold, normal);
+  } else {
+    console.warn(`https://svelte.dev/e/lifecycle_double_unmount`);
+  }
+}
+function state_proxy_equality_mismatch(operator) {
+  if (dev_fallback_default) {
+    console.warn(`%c[svelte] state_proxy_equality_mismatch
+%cReactive \`$state(...)\` proxies and the values they proxy have different identities. Because of this, comparisons with \`${operator}\` will produce unexpected results
+https://svelte.dev/e/state_proxy_equality_mismatch`, bold, normal);
+  } else {
+    console.warn(`https://svelte.dev/e/state_proxy_equality_mismatch`);
+  }
+}
+function state_proxy_unmount() {
+  if (dev_fallback_default) {
+    console.warn(`%c[svelte] state_proxy_unmount
+%cTried to unmount a state proxy, rather than a component
+https://svelte.dev/e/state_proxy_unmount`, bold, normal);
+  } else {
+    console.warn(`https://svelte.dev/e/state_proxy_unmount`);
+  }
+}
+function svelte_boundary_reset_noop() {
+  if (dev_fallback_default) {
+    console.warn(`%c[svelte] svelte_boundary_reset_noop
+%cA \`<svelte:boundary>\` \`reset\` function only resets the boundary the first time it is called
+https://svelte.dev/e/svelte_boundary_reset_noop`, bold, normal);
+  } else {
+    console.warn(`https://svelte.dev/e/svelte_boundary_reset_noop`);
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/hydration.js
+var hydrating = false;
+function set_hydrating(value) {
+  hydrating = value;
+}
+var hydrate_node;
+function set_hydrate_node(node) {
+  if (node === null) {
+    hydration_mismatch();
+    throw HYDRATION_ERROR;
+  }
+  return hydrate_node = node;
+}
+function hydrate_next() {
+  return set_hydrate_node(get_next_sibling(hydrate_node));
+}
+function reset(node) {
+  if (!hydrating) return;
+  if (get_next_sibling(hydrate_node) !== null) {
+    hydration_mismatch();
+    throw HYDRATION_ERROR;
+  }
+  hydrate_node = node;
+}
+function next(count = 1) {
+  if (hydrating) {
+    var i = count;
+    var node = hydrate_node;
+    while (i--) {
+      node = /** @type {TemplateNode} */
+      get_next_sibling(node);
+    }
+    hydrate_node = node;
+  }
+}
+function skip_nodes(remove = true) {
+  var depth = 0;
+  var node = hydrate_node;
+  while (true) {
+    if (node.nodeType === COMMENT_NODE) {
+      var data = (
+        /** @type {Comment} */
+        node.data
+      );
+      if (data === HYDRATION_END) {
+        if (depth === 0) return node;
+        depth -= 1;
+      } else if (data === HYDRATION_START || data === HYDRATION_START_ELSE || // "[1", "[2", etc. for if blocks
+      data[0] === "[" && !isNaN(Number(data.slice(1)))) {
+        depth += 1;
+      }
+    }
+    var next2 = (
+      /** @type {TemplateNode} */
+      get_next_sibling(node)
+    );
+    if (remove) node.remove();
+    node = next2;
+  }
+}
+function read_hydration_instruction(node) {
+  if (!node || node.nodeType !== COMMENT_NODE) {
+    hydration_mismatch();
+    throw HYDRATION_ERROR;
+  }
+  return (
+    /** @type {Comment} */
+    node.data
+  );
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/reactivity/equality.js
+function equals(value) {
+  return value === this.v;
+}
+function safe_not_equal(a, b) {
+  return a != a ? b == b : a !== b || a !== null && typeof a === "object" || typeof a === "function";
+}
+function safe_equals(value) {
+  return !safe_not_equal(value, this.v);
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/flags/index.js
+var async_mode_flag = false;
+var legacy_mode_flag = false;
+var tracing_mode_flag = false;
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dev/tracing.js
+var tracing_expressions = null;
+function tag(source2, label) {
+  source2.label = label;
+  tag_proxy(source2.v, label);
+  return source2;
+}
+function tag_proxy(value, label) {
+  var _a5;
+  (_a5 = value == null ? void 0 : value[PROXY_PATH_SYMBOL]) == null ? void 0 : _a5.call(value, label);
+  return value;
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/shared/dev.js
+function get_error(label) {
+  const error = new Error();
+  const stack2 = get_stack();
+  if (stack2.length === 0) {
+    return null;
+  }
+  stack2.unshift("\n");
+  define_property(error, "stack", {
+    value: stack2.join("\n")
+  });
+  define_property(error, "name", {
+    value: label
+  });
+  return (
+    /** @type {Error & { stack: string }} */
+    error
+  );
+}
+function get_stack() {
+  const limit = Error.stackTraceLimit;
+  Error.stackTraceLimit = Infinity;
+  const stack2 = new Error().stack;
+  Error.stackTraceLimit = limit;
+  if (!stack2) return [];
+  const lines = stack2.split("\n");
+  const new_lines = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const posixified = line.replaceAll("\\", "/");
+    if (line.trim() === "Error") {
+      continue;
+    }
+    if (line.includes("validate_each_keys")) {
+      return [];
+    }
+    if (posixified.includes("svelte/src/internal") || posixified.includes("node_modules/.vite")) {
+      continue;
+    }
+    new_lines.push(line);
+  }
+  return new_lines;
+}
+function invariant(condition, message) {
+  if (!dev_fallback_default) {
+    throw new Error("invariant(...) was not guarded by if (DEV)");
+  }
+  if (!condition) invariant_violation(message);
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/context.js
+var component_context = null;
+function set_component_context(context) {
+  component_context = context;
+}
+var dev_stack = null;
+function set_dev_stack(stack2) {
+  dev_stack = stack2;
+}
+var dev_current_component_function = null;
+function set_dev_current_component_function(fn) {
+  dev_current_component_function = fn;
+}
+function push(props, runes = false, fn) {
+  component_context = {
+    p: component_context,
+    i: false,
+    c: null,
+    e: null,
+    s: props,
+    x: null,
+    r: (
+      /** @type {Effect} */
+      active_effect
+    ),
+    l: legacy_mode_flag && !runes ? { s: null, u: null, $: [] } : null
+  };
+  if (dev_fallback_default) {
+    component_context.function = fn;
+    dev_current_component_function = fn;
+  }
+}
+function pop(component2) {
+  var _a5;
+  var context = (
+    /** @type {ComponentContext} */
+    component_context
+  );
+  var effects = context.e;
+  if (effects !== null) {
+    context.e = null;
+    for (var fn of effects) {
+      create_user_effect(fn);
+    }
+  }
+  if (component2 !== void 0) {
+    context.x = component2;
+  }
+  context.i = true;
+  component_context = context.p;
+  if (dev_fallback_default) {
+    dev_current_component_function = (_a5 = component_context == null ? void 0 : component_context.function) != null ? _a5 : null;
+  }
+  return component2 != null ? component2 : (
+    /** @type {T} */
+    {}
+  );
+}
+function is_runes() {
+  return !legacy_mode_flag || component_context !== null && component_context.l === null;
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/task.js
+var micro_tasks = [];
+function run_micro_tasks() {
+  var tasks = micro_tasks;
+  micro_tasks = [];
+  run_all(tasks);
+}
+function queue_micro_task(fn) {
+  if (micro_tasks.length === 0 && !is_flushing_sync) {
+    var tasks = micro_tasks;
+    queueMicrotask(() => {
+      if (tasks === micro_tasks) run_micro_tasks();
+    });
+  }
+  micro_tasks.push(fn);
+}
+function flush_tasks() {
+  while (micro_tasks.length > 0) {
+    run_micro_tasks();
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/error-handling.js
+var adjustments = /* @__PURE__ */ new WeakMap();
+function handle_error(error) {
+  var effect2 = active_effect;
+  if (effect2 === null) {
+    active_reaction.f |= ERROR_VALUE;
+    return error;
+  }
+  if (dev_fallback_default && error instanceof Error && !adjustments.has(error)) {
+    adjustments.set(error, get_adjustments(error, effect2));
+  }
+  if ((effect2.f & REACTION_RAN) === 0 && (effect2.f & EFFECT) === 0) {
+    if (dev_fallback_default && !effect2.parent && error instanceof Error) {
+      apply_adjustments(error);
+    }
+    throw error;
+  }
+  invoke_error_boundary(error, effect2);
+}
+function invoke_error_boundary(error, effect2) {
+  while (effect2 !== null) {
+    if ((effect2.f & BOUNDARY_EFFECT) !== 0) {
+      if ((effect2.f & REACTION_RAN) === 0) {
+        throw error;
+      }
+      try {
+        effect2.b.error(error);
+        return;
+      } catch (e) {
+        error = e;
+      }
+    }
+    effect2 = effect2.parent;
+  }
+  if (dev_fallback_default && error instanceof Error) {
+    apply_adjustments(error);
+  }
+  throw error;
+}
+function get_adjustments(error, effect2) {
+  var _a5, _b3, _c2;
+  const message_descriptor = get_descriptor(error, "message");
+  if (message_descriptor && !message_descriptor.configurable) return;
+  var indent = is_firefox ? "  " : "	";
+  var component_stack = `
+${indent}in ${((_a5 = effect2.fn) == null ? void 0 : _a5.name) || "<unknown>"}`;
+  var context = effect2.ctx;
+  while (context !== null) {
+    component_stack += `
+${indent}in ${(_b3 = context.function) == null ? void 0 : _b3[FILENAME].split("/").pop()}`;
+    context = context.p;
+  }
+  return {
+    message: error.message + `
+${component_stack}
+`,
+    stack: (_c2 = error.stack) == null ? void 0 : _c2.split("\n").filter((line) => !line.includes("svelte/src/internal")).join("\n")
+  };
+}
+function apply_adjustments(error) {
+  const adjusted = adjustments.get(error);
+  if (adjusted) {
+    define_property(error, "message", {
+      value: adjusted.message
+    });
+    define_property(error, "stack", {
+      value: adjusted.stack
+    });
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/reactivity/status.js
+var STATUS_MASK = ~(DIRTY | MAYBE_DIRTY | CLEAN);
+function set_signal_status(signal, status) {
+  signal.f = signal.f & STATUS_MASK | status;
+}
+function update_derived_status(derived2) {
+  if ((derived2.f & CONNECTED) !== 0 || derived2.deps === null) {
+    set_signal_status(derived2, CLEAN);
+  } else {
+    set_signal_status(derived2, MAYBE_DIRTY);
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/reactivity/utils.js
+function clear_marked(deps) {
+  if (deps === null) return;
+  for (const dep of deps) {
+    if ((dep.f & DERIVED) === 0 || (dep.f & WAS_MARKED) === 0) {
+      continue;
+    }
+    dep.f ^= WAS_MARKED;
+    clear_marked(
+      /** @type {Derived} */
+      dep.deps
+    );
+  }
+}
+function defer_effect(effect2, dirty_effects, maybe_dirty_effects) {
+  if ((effect2.f & DIRTY) !== 0) {
+    dirty_effects.add(effect2);
+  } else if ((effect2.f & MAYBE_DIRTY) !== 0) {
+    maybe_dirty_effects.add(effect2);
+  }
+  clear_marked(effect2.deps);
+  set_signal_status(effect2, CLEAN);
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/reactivity/store.js
+var legacy_is_updating_store = false;
+var IS_UNMOUNTED = Symbol();
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/reactivity/batch.js
+var batches = /* @__PURE__ */ new Set();
+var current_batch = null;
+var previous_batch = null;
+var batch_values = null;
+var last_scheduled_effect = null;
+var is_flushing_sync = false;
+var is_processing = false;
+var collected_effects = null;
+var legacy_updates = null;
+var flush_count = 0;
+var source_stacks = dev_fallback_default ? /* @__PURE__ */ new Set() : null;
+var uid = 1;
+var _commit_callbacks, _discard_callbacks, _fork_commit_callbacks, _pending, _blocking_pending, _deferred, _roots, _new_effects, _dirty_effects, _maybe_dirty_effects, _skipped_branches, _unskipped_branches, _decrement_queued, _blockers, _Batch_instances, is_deferred_fn, is_blocked_fn, process_fn, traverse_fn, defer_effects_fn, commit_fn;
+var _Batch = class _Batch {
+  constructor() {
+    __privateAdd(this, _Batch_instances);
+    __publicField(this, "id", uid++);
+    /**
+     * The current values of any signals that are updated in this batch.
+     * Tuple format: [value, is_derived] (note: is_derived is false for deriveds, too, if they were overridden via assignment)
+     * They keys of this map are identical to `this.#previous`
+     * @type {Map<Value, [any, boolean]>}
+     */
+    __publicField(this, "current", /* @__PURE__ */ new Map());
+    /**
+     * The values of any signals (sources and deriveds) that are updated in this batch _before_ those updates took place.
+     * They keys of this map are identical to `this.#current`
+     * @type {Map<Value, any>}
+     */
+    __publicField(this, "previous", /* @__PURE__ */ new Map());
+    /**
+     * When the batch is committed (and the DOM is updated), we need to remove old branches
+     * and append new ones by calling the functions added inside (if/each/key/etc) blocks
+     * @type {Set<(batch: Batch) => void>}
+     */
+    __privateAdd(this, _commit_callbacks, /* @__PURE__ */ new Set());
+    /**
+     * If a fork is discarded, we need to destroy any effects that are no longer needed
+     * @type {Set<(batch: Batch) => void>}
+     */
+    __privateAdd(this, _discard_callbacks, /* @__PURE__ */ new Set());
+    /**
+     * Callbacks that should run only when a fork is committed.
+     * @type {Set<(batch: Batch) => void>}
+     */
+    __privateAdd(this, _fork_commit_callbacks, /* @__PURE__ */ new Set());
+    /**
+     * Async effects that are currently in flight
+     * @type {Map<Effect, number>}
+     */
+    __privateAdd(this, _pending, /* @__PURE__ */ new Map());
+    /**
+     * Async effects that are currently in flight, _not_ inside a pending boundary
+     * @type {Map<Effect, number>}
+     */
+    __privateAdd(this, _blocking_pending, /* @__PURE__ */ new Map());
+    /**
+     * A deferred that resolves when the batch is committed, used with `settled()`
+     * TODO replace with Promise.withResolvers once supported widely enough
+     * @type {{ promise: Promise<void>, resolve: (value?: any) => void, reject: (reason: unknown) => void } | null}
+     */
+    __privateAdd(this, _deferred, null);
+    /**
+     * The root effects that need to be flushed
+     * @type {Effect[]}
+     */
+    __privateAdd(this, _roots, []);
+    /**
+     * Effects created while this batch was active.
+     * @type {Effect[]}
+     */
+    __privateAdd(this, _new_effects, []);
+    /**
+     * Deferred effects (which run after async work has completed) that are DIRTY
+     * @type {Set<Effect>}
+     */
+    __privateAdd(this, _dirty_effects, /* @__PURE__ */ new Set());
+    /**
+     * Deferred effects that are MAYBE_DIRTY
+     * @type {Set<Effect>}
+     */
+    __privateAdd(this, _maybe_dirty_effects, /* @__PURE__ */ new Set());
+    /**
+     * A map of branches that still exist, but will be destroyed when this batch
+     * is committed — we skip over these during `process`.
+     * The value contains child effects that were dirty/maybe_dirty before being reset,
+     * so they can be rescheduled if the branch survives.
+     * @type {Map<Effect, { d: Effect[], m: Effect[] }>}
+     */
+    __privateAdd(this, _skipped_branches, /* @__PURE__ */ new Map());
+    /**
+     * Inverse of #skipped_branches which we need to tell prior batches to unskip them when committing
+     * @type {Set<Effect>}
+     */
+    __privateAdd(this, _unskipped_branches, /* @__PURE__ */ new Set());
+    __publicField(this, "is_fork", false);
+    __privateAdd(this, _decrement_queued, false);
+    /** @type {Set<Batch>} */
+    __privateAdd(this, _blockers, /* @__PURE__ */ new Set());
+  }
+  /**
+   * Add an effect to the #skipped_branches map and reset its children
+   * @param {Effect} effect
+   */
+  skip_effect(effect2) {
+    if (!__privateGet(this, _skipped_branches).has(effect2)) {
+      __privateGet(this, _skipped_branches).set(effect2, { d: [], m: [] });
+    }
+    __privateGet(this, _unskipped_branches).delete(effect2);
+  }
+  /**
+   * Remove an effect from the #skipped_branches map and reschedule
+   * any tracked dirty/maybe_dirty child effects
+   * @param {Effect} effect
+   * @param {(e: Effect) => void} callback
+   */
+  unskip_effect(effect2, callback = (e) => this.schedule(e)) {
+    var tracked = __privateGet(this, _skipped_branches).get(effect2);
+    if (tracked) {
+      __privateGet(this, _skipped_branches).delete(effect2);
+      for (var e of tracked.d) {
+        set_signal_status(e, DIRTY);
+        callback(e);
+      }
+      for (e of tracked.m) {
+        set_signal_status(e, MAYBE_DIRTY);
+        callback(e);
+      }
+    }
+    __privateGet(this, _unskipped_branches).add(effect2);
+  }
+  /**
+   * Associate a change to a given source with the current
+   * batch, noting its previous and current values
+   * @param {Value} source
+   * @param {any} value
+   * @param {boolean} [is_derived]
+   */
+  capture(source2, value, is_derived = false) {
+    if (source2.v !== UNINITIALIZED && !this.previous.has(source2)) {
+      this.previous.set(source2, source2.v);
+    }
+    if ((source2.f & ERROR_VALUE) === 0) {
+      this.current.set(source2, [value, is_derived]);
+      batch_values == null ? void 0 : batch_values.set(source2, value);
+    }
+    if (!this.is_fork) {
+      source2.v = value;
+    }
+  }
+  activate() {
+    current_batch = this;
+  }
+  deactivate() {
+    current_batch = null;
+    batch_values = null;
+  }
+  flush() {
+    var source_stacks2 = dev_fallback_default ? /* @__PURE__ */ new Set() : null;
+    try {
+      is_processing = true;
+      current_batch = this;
+      __privateMethod(this, _Batch_instances, process_fn).call(this);
+    } finally {
+      flush_count = 0;
+      last_scheduled_effect = null;
+      collected_effects = null;
+      legacy_updates = null;
+      is_processing = false;
+      current_batch = null;
+      batch_values = null;
+      old_values.clear();
+      if (dev_fallback_default) {
+        for (
+          const source2 of
+          /** @type {Set<Source>} */
+          source_stacks2
+        ) {
+          source2.updated = null;
+        }
+      }
+    }
+  }
+  discard() {
+    for (const fn of __privateGet(this, _discard_callbacks)) fn(this);
+    __privateGet(this, _discard_callbacks).clear();
+    __privateGet(this, _fork_commit_callbacks).clear();
+    batches.delete(this);
+  }
+  /**
+   * @param {Effect} effect
+   */
+  register_created_effect(effect2) {
+    __privateGet(this, _new_effects).push(effect2);
+  }
+  /**
+   * @param {boolean} blocking
+   * @param {Effect} effect
+   */
+  increment(blocking, effect2) {
+    var _a5, _b3;
+    let pending_count = (_a5 = __privateGet(this, _pending).get(effect2)) != null ? _a5 : 0;
+    __privateGet(this, _pending).set(effect2, pending_count + 1);
+    if (blocking) {
+      let blocking_pending_count = (_b3 = __privateGet(this, _blocking_pending).get(effect2)) != null ? _b3 : 0;
+      __privateGet(this, _blocking_pending).set(effect2, blocking_pending_count + 1);
+    }
+  }
+  /**
+   * @param {boolean} blocking
+   * @param {Effect} effect
+   * @param {boolean} skip - whether to skip updates (because this is triggered by a stale reaction)
+   */
+  decrement(blocking, effect2, skip) {
+    var _a5, _b3;
+    let pending_count = (_a5 = __privateGet(this, _pending).get(effect2)) != null ? _a5 : 0;
+    if (pending_count === 1) {
+      __privateGet(this, _pending).delete(effect2);
+    } else {
+      __privateGet(this, _pending).set(effect2, pending_count - 1);
+    }
+    if (blocking) {
+      let blocking_pending_count = (_b3 = __privateGet(this, _blocking_pending).get(effect2)) != null ? _b3 : 0;
+      if (blocking_pending_count === 1) {
+        __privateGet(this, _blocking_pending).delete(effect2);
+      } else {
+        __privateGet(this, _blocking_pending).set(effect2, blocking_pending_count - 1);
+      }
+    }
+    if (__privateGet(this, _decrement_queued) || skip) return;
+    __privateSet(this, _decrement_queued, true);
+    queue_micro_task(() => {
+      __privateSet(this, _decrement_queued, false);
+      this.flush();
+    });
+  }
+  /**
+   * @param {Set<Effect>} dirty_effects
+   * @param {Set<Effect>} maybe_dirty_effects
+   */
+  transfer_effects(dirty_effects, maybe_dirty_effects) {
+    for (const e of dirty_effects) {
+      __privateGet(this, _dirty_effects).add(e);
+    }
+    for (const e of maybe_dirty_effects) {
+      __privateGet(this, _maybe_dirty_effects).add(e);
+    }
+    dirty_effects.clear();
+    maybe_dirty_effects.clear();
+  }
+  /** @param {(batch: Batch) => void} fn */
+  oncommit(fn) {
+    __privateGet(this, _commit_callbacks).add(fn);
+  }
+  /** @param {(batch: Batch) => void} fn */
+  ondiscard(fn) {
+    __privateGet(this, _discard_callbacks).add(fn);
+  }
+  /** @param {(batch: Batch) => void} fn */
+  on_fork_commit(fn) {
+    __privateGet(this, _fork_commit_callbacks).add(fn);
+  }
+  run_fork_commit_callbacks() {
+    for (const fn of __privateGet(this, _fork_commit_callbacks)) fn(this);
+    __privateGet(this, _fork_commit_callbacks).clear();
+  }
+  settled() {
+    var _a5;
+    return ((_a5 = __privateGet(this, _deferred)) != null ? _a5 : __privateSet(this, _deferred, deferred())).promise;
+  }
+  static ensure() {
+    if (current_batch === null) {
+      const batch = current_batch = new _Batch();
+      if (!is_processing) {
+        batches.add(current_batch);
+        if (!is_flushing_sync) {
+          queue_micro_task(() => {
+            if (current_batch !== batch) {
+              return;
+            }
+            batch.flush();
+          });
+        }
+      }
+    }
+    return current_batch;
+  }
+  apply() {
+    if (!async_mode_flag || !this.is_fork && batches.size === 1) {
+      batch_values = null;
+      return;
+    }
+    batch_values = /* @__PURE__ */ new Map();
+    for (const [source2, [value]] of this.current) {
+      batch_values.set(source2, value);
+    }
+    for (const batch of batches) {
+      if (batch === this || batch.is_fork) continue;
+      var intersects = false;
+      var differs = false;
+      if (batch.id < this.id) {
+        for (const [source2, [, is_derived]] of batch.current) {
+          if (is_derived) continue;
+          intersects || (intersects = this.current.has(source2));
+          differs || (differs = !this.current.has(source2));
+        }
+      }
+      if (intersects && differs) {
+        __privateGet(this, _blockers).add(batch);
+      } else {
+        for (const [source2, previous] of batch.previous) {
+          if (!batch_values.has(source2)) {
+            batch_values.set(source2, previous);
+          }
+        }
+      }
+    }
+  }
+  /**
+   *
+   * @param {Effect} effect
+   */
+  schedule(effect2) {
+    var _a5;
+    last_scheduled_effect = effect2;
+    if (((_a5 = effect2.b) == null ? void 0 : _a5.is_pending) && (effect2.f & (EFFECT | RENDER_EFFECT | MANAGED_EFFECT)) !== 0 && (effect2.f & REACTION_RAN) === 0) {
+      effect2.b.defer_effect(effect2);
+      return;
+    }
+    var e = effect2;
+    while (e.parent !== null) {
+      e = e.parent;
+      var flags2 = e.f;
+      if (collected_effects !== null && e === active_effect) {
+        if (async_mode_flag) return;
+        if ((active_reaction === null || (active_reaction.f & DERIVED) === 0) && !legacy_is_updating_store) {
+          return;
+        }
+      }
+      if ((flags2 & (ROOT_EFFECT | BRANCH_EFFECT)) !== 0) {
+        if ((flags2 & CLEAN) === 0) {
+          return;
+        }
+        e.f ^= CLEAN;
+      }
+    }
+    __privateGet(this, _roots).push(e);
+  }
+};
+_commit_callbacks = new WeakMap();
+_discard_callbacks = new WeakMap();
+_fork_commit_callbacks = new WeakMap();
+_pending = new WeakMap();
+_blocking_pending = new WeakMap();
+_deferred = new WeakMap();
+_roots = new WeakMap();
+_new_effects = new WeakMap();
+_dirty_effects = new WeakMap();
+_maybe_dirty_effects = new WeakMap();
+_skipped_branches = new WeakMap();
+_unskipped_branches = new WeakMap();
+_decrement_queued = new WeakMap();
+_blockers = new WeakMap();
+_Batch_instances = new WeakSet();
+is_deferred_fn = function() {
+  return this.is_fork || __privateGet(this, _blocking_pending).size > 0;
+};
+is_blocked_fn = function() {
+  for (const batch of __privateGet(this, _blockers)) {
+    for (const effect2 of __privateGet(batch, _blocking_pending).keys()) {
+      var skipped = false;
+      var e = effect2;
+      while (e.parent !== null) {
+        if (__privateGet(this, _skipped_branches).has(e)) {
+          skipped = true;
+          break;
+        }
+        e = e.parent;
+      }
+      if (!skipped) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+process_fn = function() {
+  var _a5, _b3;
+  if (flush_count++ > 1e3) {
+    batches.delete(this);
+    infinite_loop_guard();
+  }
+  if (!__privateMethod(this, _Batch_instances, is_deferred_fn).call(this)) {
+    for (const e of __privateGet(this, _dirty_effects)) {
+      __privateGet(this, _maybe_dirty_effects).delete(e);
+      set_signal_status(e, DIRTY);
+      this.schedule(e);
+    }
+    for (const e of __privateGet(this, _maybe_dirty_effects)) {
+      set_signal_status(e, MAYBE_DIRTY);
+      this.schedule(e);
+    }
+  }
+  const roots = __privateGet(this, _roots);
+  __privateSet(this, _roots, []);
+  this.apply();
+  var effects = collected_effects = [];
+  var render_effects = [];
+  var updates = legacy_updates = [];
+  for (const root3 of roots) {
+    try {
+      __privateMethod(this, _Batch_instances, traverse_fn).call(this, root3, effects, render_effects);
+    } catch (e) {
+      reset_all(root3);
+      throw e;
+    }
+  }
+  current_batch = null;
+  if (updates.length > 0) {
+    var batch = _Batch.ensure();
+    for (const e of updates) {
+      batch.schedule(e);
+    }
+  }
+  collected_effects = null;
+  legacy_updates = null;
+  if (__privateMethod(this, _Batch_instances, is_deferred_fn).call(this) || __privateMethod(this, _Batch_instances, is_blocked_fn).call(this)) {
+    __privateMethod(this, _Batch_instances, defer_effects_fn).call(this, render_effects);
+    __privateMethod(this, _Batch_instances, defer_effects_fn).call(this, effects);
+    for (const [e, t] of __privateGet(this, _skipped_branches)) {
+      reset_branch(e, t);
+    }
+  } else {
+    if (__privateGet(this, _pending).size === 0) {
+      batches.delete(this);
+    }
+    __privateGet(this, _dirty_effects).clear();
+    __privateGet(this, _maybe_dirty_effects).clear();
+    for (const fn of __privateGet(this, _commit_callbacks)) fn(this);
+    __privateGet(this, _commit_callbacks).clear();
+    previous_batch = this;
+    flush_queued_effects(render_effects);
+    flush_queued_effects(effects);
+    previous_batch = null;
+    (_a5 = __privateGet(this, _deferred)) == null ? void 0 : _a5.resolve();
+  }
+  var next_batch = (
+    /** @type {Batch | null} */
+    /** @type {unknown} */
+    current_batch
+  );
+  if (__privateGet(this, _roots).length > 0) {
+    const batch2 = next_batch != null ? next_batch : next_batch = this;
+    __privateGet(batch2, _roots).push(...__privateGet(this, _roots).filter((r) => !__privateGet(batch2, _roots).includes(r)));
+  }
+  if (next_batch !== null) {
+    batches.add(next_batch);
+    if (dev_fallback_default) {
+      for (const source2 of this.current.keys()) {
+        source_stacks.add(source2);
+      }
+    }
+    __privateMethod(_b3 = next_batch, _Batch_instances, process_fn).call(_b3);
+  }
+  if (async_mode_flag && !batches.has(this)) {
+    __privateMethod(this, _Batch_instances, commit_fn).call(this);
+  }
+};
+/**
+ * Traverse the effect tree, executing effects or stashing
+ * them for later execution as appropriate
+ * @param {Effect} root
+ * @param {Effect[]} effects
+ * @param {Effect[]} render_effects
+ */
+traverse_fn = function(root3, effects, render_effects) {
+  root3.f ^= CLEAN;
+  var effect2 = root3.first;
+  while (effect2 !== null) {
+    var flags2 = effect2.f;
+    var is_branch = (flags2 & (BRANCH_EFFECT | ROOT_EFFECT)) !== 0;
+    var is_skippable_branch = is_branch && (flags2 & CLEAN) !== 0;
+    var skip = is_skippable_branch || (flags2 & INERT) !== 0 || __privateGet(this, _skipped_branches).has(effect2);
+    if (!skip && effect2.fn !== null) {
+      if (is_branch) {
+        effect2.f ^= CLEAN;
+      } else if ((flags2 & EFFECT) !== 0) {
+        effects.push(effect2);
+      } else if (async_mode_flag && (flags2 & (RENDER_EFFECT | MANAGED_EFFECT)) !== 0) {
+        render_effects.push(effect2);
+      } else if (is_dirty(effect2)) {
+        if ((flags2 & BLOCK_EFFECT) !== 0) __privateGet(this, _maybe_dirty_effects).add(effect2);
+        update_effect(effect2);
+      }
+      var child2 = effect2.first;
+      if (child2 !== null) {
+        effect2 = child2;
+        continue;
+      }
+    }
+    while (effect2 !== null) {
+      var next2 = effect2.next;
+      if (next2 !== null) {
+        effect2 = next2;
+        break;
+      }
+      effect2 = effect2.parent;
+    }
+  }
+};
+/**
+ * @param {Effect[]} effects
+ */
+defer_effects_fn = function(effects) {
+  for (var i = 0; i < effects.length; i += 1) {
+    defer_effect(effects[i], __privateGet(this, _dirty_effects), __privateGet(this, _maybe_dirty_effects));
+  }
+};
+commit_fn = function() {
+  var _a5, _b3, _c2;
+  for (const batch of batches) {
+    var is_earlier = batch.id < this.id;
+    var sources = [];
+    for (const [source3, [value, is_derived]] of this.current) {
+      if (batch.current.has(source3)) {
+        var batch_value = (
+          /** @type {[any, boolean]} */
+          batch.current.get(source3)[0]
+        );
+        if (is_earlier && value !== batch_value) {
+          batch.current.set(source3, [value, is_derived]);
+        } else {
+          continue;
+        }
+      }
+      sources.push(source3);
+    }
+    var others = [...batch.current.keys()].filter((s) => !this.current.has(s));
+    if (others.length === 0) {
+      if (is_earlier) {
+        batch.discard();
+      }
+    } else if (sources.length > 0) {
+      if (dev_fallback_default) {
+        invariant(__privateGet(batch, _roots).length === 0, "Batch has scheduled roots");
+      }
+      if (is_earlier) {
+        for (const unskipped of __privateGet(this, _unskipped_branches)) {
+          batch.unskip_effect(unskipped, (e) => {
+            var _a6;
+            if ((e.f & (BLOCK_EFFECT | ASYNC)) !== 0) {
+              batch.schedule(e);
+            } else {
+              __privateMethod(_a6 = batch, _Batch_instances, defer_effects_fn).call(_a6, [e]);
+            }
+          });
+        }
+      }
+      batch.activate();
+      var marked = /* @__PURE__ */ new Set();
+      var checked = /* @__PURE__ */ new Map();
+      for (var source2 of sources) {
+        mark_effects(source2, others, marked, checked);
+      }
+      checked = /* @__PURE__ */ new Map();
+      var current_unequal = [...batch.current.keys()].filter(
+        (c) => this.current.has(c) ? (
+          /** @type {[any, boolean]} */
+          this.current.get(c)[0] !== c
+        ) : true
+      );
+      for (const effect2 of __privateGet(this, _new_effects)) {
+        if ((effect2.f & (DESTROYED | INERT | EAGER_EFFECT)) === 0 && depends_on(effect2, current_unequal, checked)) {
+          if ((effect2.f & (ASYNC | BLOCK_EFFECT)) !== 0) {
+            set_signal_status(effect2, DIRTY);
+            batch.schedule(effect2);
+          } else {
+            __privateGet(batch, _dirty_effects).add(effect2);
+          }
+        }
+      }
+      if (__privateGet(batch, _roots).length > 0) {
+        batch.apply();
+        for (var root3 of __privateGet(batch, _roots)) {
+          __privateMethod(_a5 = batch, _Batch_instances, traverse_fn).call(_a5, root3, [], []);
+        }
+        __privateSet(batch, _roots, []);
+      }
+      batch.deactivate();
+    }
+  }
+  for (const batch of batches) {
+    if (__privateGet(batch, _blockers).has(this)) {
+      __privateGet(batch, _blockers).delete(this);
+      if (__privateGet(batch, _blockers).size === 0 && !__privateMethod(_b3 = batch, _Batch_instances, is_deferred_fn).call(_b3)) {
+        batch.activate();
+        __privateMethod(_c2 = batch, _Batch_instances, process_fn).call(_c2);
+      }
+    }
+  }
+};
+var Batch = _Batch;
+function flushSync(fn) {
+  var was_flushing_sync = is_flushing_sync;
+  is_flushing_sync = true;
+  try {
+    var result;
+    if (fn) {
+      if (current_batch !== null && !current_batch.is_fork) {
+        current_batch.flush();
+      }
+      result = fn();
+    }
+    while (true) {
+      flush_tasks();
+      if (current_batch === null) {
+        return (
+          /** @type {T} */
+          result
+        );
+      }
+      current_batch.flush();
+    }
+  } finally {
+    is_flushing_sync = was_flushing_sync;
+  }
+}
+function infinite_loop_guard() {
+  var _a5;
+  if (dev_fallback_default) {
+    var updates = /* @__PURE__ */ new Map();
+    for (
+      const source2 of
+      /** @type {Batch} */
+      current_batch.current.keys()
+    ) {
+      for (const [stack2, update2] of (_a5 = source2.updated) != null ? _a5 : []) {
+        var entry = updates.get(stack2);
+        if (!entry) {
+          entry = { error: update2.error, count: 0 };
+          updates.set(stack2, entry);
+        }
+        entry.count += update2.count;
+      }
+    }
+    for (const update2 of updates.values()) {
+      if (update2.error) {
+        console.error(update2.error);
+      }
+    }
+  }
+  try {
+    effect_update_depth_exceeded();
+  } catch (error) {
+    if (dev_fallback_default) {
+      define_property(error, "stack", { value: "" });
+    }
+    invoke_error_boundary(error, last_scheduled_effect);
+  }
+}
+var eager_block_effects = null;
+function flush_queued_effects(effects) {
+  var length = effects.length;
+  if (length === 0) return;
+  var i = 0;
+  while (i < length) {
+    var effect2 = effects[i++];
+    if ((effect2.f & (DESTROYED | INERT)) === 0 && is_dirty(effect2)) {
+      eager_block_effects = /* @__PURE__ */ new Set();
+      update_effect(effect2);
+      if (effect2.deps === null && effect2.first === null && effect2.nodes === null && effect2.teardown === null && effect2.ac === null) {
+        unlink_effect(effect2);
+      }
+      if ((eager_block_effects == null ? void 0 : eager_block_effects.size) > 0) {
+        old_values.clear();
+        for (const e of eager_block_effects) {
+          if ((e.f & (DESTROYED | INERT)) !== 0) continue;
+          const ordered_effects = [e];
+          let ancestor = e.parent;
+          while (ancestor !== null) {
+            if (eager_block_effects.has(ancestor)) {
+              eager_block_effects.delete(ancestor);
+              ordered_effects.push(ancestor);
+            }
+            ancestor = ancestor.parent;
+          }
+          for (let j = ordered_effects.length - 1; j >= 0; j--) {
+            const e2 = ordered_effects[j];
+            if ((e2.f & (DESTROYED | INERT)) !== 0) continue;
+            update_effect(e2);
+          }
+        }
+        eager_block_effects.clear();
+      }
+    }
+  }
+  eager_block_effects = null;
+}
+function mark_effects(value, sources, marked, checked) {
+  if (marked.has(value)) return;
+  marked.add(value);
+  if (value.reactions !== null) {
+    for (const reaction of value.reactions) {
+      const flags2 = reaction.f;
+      if ((flags2 & DERIVED) !== 0) {
+        mark_effects(
+          /** @type {Derived} */
+          reaction,
+          sources,
+          marked,
+          checked
+        );
+      } else if ((flags2 & (ASYNC | BLOCK_EFFECT)) !== 0 && (flags2 & DIRTY) === 0 && depends_on(reaction, sources, checked)) {
+        set_signal_status(reaction, DIRTY);
+        schedule_effect(
+          /** @type {Effect} */
+          reaction
+        );
+      }
+    }
+  }
+}
+function depends_on(reaction, sources, checked) {
+  const depends = checked.get(reaction);
+  if (depends !== void 0) return depends;
+  if (reaction.deps !== null) {
+    for (const dep of reaction.deps) {
+      if (includes.call(sources, dep)) {
+        return true;
+      }
+      if ((dep.f & DERIVED) !== 0 && depends_on(
+        /** @type {Derived} */
+        dep,
+        sources,
+        checked
+      )) {
+        checked.set(
+          /** @type {Derived} */
+          dep,
+          true
+        );
+        return true;
+      }
+    }
+  }
+  checked.set(reaction, false);
+  return false;
+}
+function schedule_effect(effect2) {
+  current_batch.schedule(effect2);
+}
+function reset_branch(effect2, tracked) {
+  if ((effect2.f & BRANCH_EFFECT) !== 0 && (effect2.f & CLEAN) !== 0) {
+    return;
+  }
+  if ((effect2.f & DIRTY) !== 0) {
+    tracked.d.push(effect2);
+  } else if ((effect2.f & MAYBE_DIRTY) !== 0) {
+    tracked.m.push(effect2);
+  }
+  set_signal_status(effect2, CLEAN);
+  var e = effect2.first;
+  while (e !== null) {
+    reset_branch(e, tracked);
+    e = e.next;
+  }
+}
+function reset_all(effect2) {
+  set_signal_status(effect2, CLEAN);
+  var e = effect2.first;
+  while (e !== null) {
+    reset_all(e);
+    e = e.next;
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/reactivity/create-subscriber.js
+function createSubscriber(start) {
+  let subscribers = 0;
+  let version = source(0);
+  let stop;
+  if (dev_fallback_default) {
+    tag(version, "createSubscriber version");
+  }
+  return () => {
+    if (effect_tracking()) {
+      get2(version);
+      render_effect(() => {
+        if (subscribers === 0) {
+          stop = untrack(() => start(() => increment(version)));
+        }
+        subscribers += 1;
+        return () => {
+          queue_micro_task(() => {
+            subscribers -= 1;
+            if (subscribers === 0) {
+              stop == null ? void 0 : stop();
+              stop = void 0;
+              increment(version);
+            }
+          });
+        };
+      });
+    }
+  };
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/blocks/boundary.js
+var flags = EFFECT_TRANSPARENT | EFFECT_PRESERVED;
+function boundary(node, props, children, transform_error) {
+  new Boundary(node, props, children, transform_error);
+}
+var _anchor, _hydrate_open, _props, _children, _effect, _main_effect, _pending_effect, _failed_effect, _offscreen_fragment, _local_pending_count, _pending_count, _pending_count_update_queued, _dirty_effects2, _maybe_dirty_effects2, _effect_pending, _effect_pending_subscriber, _Boundary_instances, hydrate_resolved_content_fn, hydrate_failed_content_fn, hydrate_pending_content_fn, render_fn, resolve_fn, run_fn, update_pending_count_fn, handle_error_fn;
+var Boundary = class {
+  /**
+   * @param {TemplateNode} node
+   * @param {BoundaryProps} props
+   * @param {((anchor: Node) => void)} children
+   * @param {((error: unknown) => unknown) | undefined} [transform_error]
+   */
+  constructor(node, props, children, transform_error) {
+    __privateAdd(this, _Boundary_instances);
+    /** @type {Boundary | null} */
+    __publicField(this, "parent");
+    __publicField(this, "is_pending", false);
+    /**
+     * API-level transformError transform function. Transforms errors before they reach the `failed` snippet.
+     * Inherited from parent boundary, or defaults to identity.
+     * @type {(error: unknown) => unknown}
+     */
+    __publicField(this, "transform_error");
+    /** @type {TemplateNode} */
+    __privateAdd(this, _anchor);
+    /** @type {TemplateNode | null} */
+    __privateAdd(this, _hydrate_open, hydrating ? hydrate_node : null);
+    /** @type {BoundaryProps} */
+    __privateAdd(this, _props);
+    /** @type {((anchor: Node) => void)} */
+    __privateAdd(this, _children);
+    /** @type {Effect} */
+    __privateAdd(this, _effect);
+    /** @type {Effect | null} */
+    __privateAdd(this, _main_effect, null);
+    /** @type {Effect | null} */
+    __privateAdd(this, _pending_effect, null);
+    /** @type {Effect | null} */
+    __privateAdd(this, _failed_effect, null);
+    /** @type {DocumentFragment | null} */
+    __privateAdd(this, _offscreen_fragment, null);
+    __privateAdd(this, _local_pending_count, 0);
+    __privateAdd(this, _pending_count, 0);
+    __privateAdd(this, _pending_count_update_queued, false);
+    /** @type {Set<Effect>} */
+    __privateAdd(this, _dirty_effects2, /* @__PURE__ */ new Set());
+    /** @type {Set<Effect>} */
+    __privateAdd(this, _maybe_dirty_effects2, /* @__PURE__ */ new Set());
+    /**
+     * A source containing the number of pending async deriveds/expressions.
+     * Only created if `$effect.pending()` is used inside the boundary,
+     * otherwise updating the source results in needless `Batch.ensure()`
+     * calls followed by no-op flushes
+     * @type {Source<number> | null}
+     */
+    __privateAdd(this, _effect_pending, null);
+    __privateAdd(this, _effect_pending_subscriber, createSubscriber(() => {
+      __privateSet(this, _effect_pending, source(__privateGet(this, _local_pending_count)));
+      if (dev_fallback_default) {
+        tag(__privateGet(this, _effect_pending), "$effect.pending()");
+      }
+      return () => {
+        __privateSet(this, _effect_pending, null);
+      };
+    }));
+    var _a5, _b3;
+    __privateSet(this, _anchor, node);
+    __privateSet(this, _props, props);
+    __privateSet(this, _children, (anchor) => {
+      var effect2 = (
+        /** @type {Effect} */
+        active_effect
+      );
+      effect2.b = this;
+      effect2.f |= BOUNDARY_EFFECT;
+      children(anchor);
+    });
+    this.parent = /** @type {Effect} */
+    active_effect.b;
+    this.transform_error = (_b3 = transform_error != null ? transform_error : (_a5 = this.parent) == null ? void 0 : _a5.transform_error) != null ? _b3 : (e) => e;
+    __privateSet(this, _effect, block(() => {
+      if (hydrating) {
+        const comment2 = (
+          /** @type {Comment} */
+          __privateGet(this, _hydrate_open)
+        );
+        hydrate_next();
+        const server_rendered_pending = comment2.data === HYDRATION_START_ELSE;
+        const server_rendered_failed = comment2.data.startsWith(HYDRATION_START_FAILED);
+        if (server_rendered_failed) {
+          const serialized_error = JSON.parse(comment2.data.slice(HYDRATION_START_FAILED.length));
+          __privateMethod(this, _Boundary_instances, hydrate_failed_content_fn).call(this, serialized_error);
+        } else if (server_rendered_pending) {
+          __privateMethod(this, _Boundary_instances, hydrate_pending_content_fn).call(this);
+        } else {
+          __privateMethod(this, _Boundary_instances, hydrate_resolved_content_fn).call(this);
+        }
+      } else {
+        __privateMethod(this, _Boundary_instances, render_fn).call(this);
+      }
+    }, flags));
+    if (hydrating) {
+      __privateSet(this, _anchor, hydrate_node);
+    }
+  }
+  /**
+   * Defer an effect inside a pending boundary until the boundary resolves
+   * @param {Effect} effect
+   */
+  defer_effect(effect2) {
+    defer_effect(effect2, __privateGet(this, _dirty_effects2), __privateGet(this, _maybe_dirty_effects2));
+  }
+  /**
+   * Returns `false` if the effect exists inside a boundary whose pending snippet is shown
+   * @returns {boolean}
+   */
+  is_rendered() {
+    return !this.is_pending && (!this.parent || this.parent.is_rendered());
+  }
+  has_pending_snippet() {
+    return !!__privateGet(this, _props).pending;
+  }
+  /**
+   * Update the source that powers `$effect.pending()` inside this boundary,
+   * and controls when the current `pending` snippet (if any) is removed.
+   * Do not call from inside the class
+   * @param {1 | -1} d
+   * @param {Batch} batch
+   */
+  update_pending_count(d, batch) {
+    __privateMethod(this, _Boundary_instances, update_pending_count_fn).call(this, d, batch);
+    __privateSet(this, _local_pending_count, __privateGet(this, _local_pending_count) + d);
+    if (!__privateGet(this, _effect_pending) || __privateGet(this, _pending_count_update_queued)) return;
+    __privateSet(this, _pending_count_update_queued, true);
+    queue_micro_task(() => {
+      __privateSet(this, _pending_count_update_queued, false);
+      if (__privateGet(this, _effect_pending)) {
+        internal_set(__privateGet(this, _effect_pending), __privateGet(this, _local_pending_count));
+      }
+    });
+  }
+  get_effect_pending() {
+    __privateGet(this, _effect_pending_subscriber).call(this);
+    return get2(
+      /** @type {Source<number>} */
+      __privateGet(this, _effect_pending)
+    );
+  }
+  /** @param {unknown} error */
+  error(error) {
+    var _a5;
+    if (!__privateGet(this, _props).onerror && !__privateGet(this, _props).failed) {
+      throw error;
+    }
+    if ((_a5 = current_batch) == null ? void 0 : _a5.is_fork) {
+      if (__privateGet(this, _main_effect)) current_batch.skip_effect(__privateGet(this, _main_effect));
+      if (__privateGet(this, _pending_effect)) current_batch.skip_effect(__privateGet(this, _pending_effect));
+      if (__privateGet(this, _failed_effect)) current_batch.skip_effect(__privateGet(this, _failed_effect));
+      current_batch.on_fork_commit(() => {
+        __privateMethod(this, _Boundary_instances, handle_error_fn).call(this, error);
+      });
+    } else {
+      __privateMethod(this, _Boundary_instances, handle_error_fn).call(this, error);
+    }
+  }
+};
+_anchor = new WeakMap();
+_hydrate_open = new WeakMap();
+_props = new WeakMap();
+_children = new WeakMap();
+_effect = new WeakMap();
+_main_effect = new WeakMap();
+_pending_effect = new WeakMap();
+_failed_effect = new WeakMap();
+_offscreen_fragment = new WeakMap();
+_local_pending_count = new WeakMap();
+_pending_count = new WeakMap();
+_pending_count_update_queued = new WeakMap();
+_dirty_effects2 = new WeakMap();
+_maybe_dirty_effects2 = new WeakMap();
+_effect_pending = new WeakMap();
+_effect_pending_subscriber = new WeakMap();
+_Boundary_instances = new WeakSet();
+hydrate_resolved_content_fn = function() {
+  try {
+    __privateSet(this, _main_effect, branch(() => __privateGet(this, _children).call(this, __privateGet(this, _anchor))));
+  } catch (error) {
+    this.error(error);
+  }
+};
+/**
+ * @param {unknown} error The deserialized error from the server's hydration comment
+ */
+hydrate_failed_content_fn = function(error) {
+  const failed = __privateGet(this, _props).failed;
+  if (!failed) return;
+  __privateSet(this, _failed_effect, branch(() => {
+    failed(
+      __privateGet(this, _anchor),
+      () => error,
+      () => () => {
+      }
+    );
+  }));
+};
+hydrate_pending_content_fn = function() {
+  const pending2 = __privateGet(this, _props).pending;
+  if (!pending2) return;
+  this.is_pending = true;
+  __privateSet(this, _pending_effect, branch(() => pending2(__privateGet(this, _anchor))));
+  queue_micro_task(() => {
+    var fragment = __privateSet(this, _offscreen_fragment, document.createDocumentFragment());
+    var anchor = create_text();
+    fragment.append(anchor);
+    __privateSet(this, _main_effect, __privateMethod(this, _Boundary_instances, run_fn).call(this, () => {
+      return branch(() => __privateGet(this, _children).call(this, anchor));
+    }));
+    if (__privateGet(this, _pending_count) === 0) {
+      __privateGet(this, _anchor).before(fragment);
+      __privateSet(this, _offscreen_fragment, null);
+      pause_effect(
+        /** @type {Effect} */
+        __privateGet(this, _pending_effect),
+        () => {
+          __privateSet(this, _pending_effect, null);
+        }
+      );
+      __privateMethod(this, _Boundary_instances, resolve_fn).call(
+        this,
+        /** @type {Batch} */
+        current_batch
+      );
+    }
+  });
+};
+render_fn = function() {
+  try {
+    this.is_pending = this.has_pending_snippet();
+    __privateSet(this, _pending_count, 0);
+    __privateSet(this, _local_pending_count, 0);
+    __privateSet(this, _main_effect, branch(() => {
+      __privateGet(this, _children).call(this, __privateGet(this, _anchor));
+    }));
+    if (__privateGet(this, _pending_count) > 0) {
+      var fragment = __privateSet(this, _offscreen_fragment, document.createDocumentFragment());
+      move_effect(__privateGet(this, _main_effect), fragment);
+      const pending2 = (
+        /** @type {(anchor: Node) => void} */
+        __privateGet(this, _props).pending
+      );
+      __privateSet(this, _pending_effect, branch(() => pending2(__privateGet(this, _anchor))));
+    } else {
+      __privateMethod(this, _Boundary_instances, resolve_fn).call(
+        this,
+        /** @type {Batch} */
+        current_batch
+      );
+    }
+  } catch (error) {
+    this.error(error);
+  }
+};
+/**
+ * @param {Batch} batch
+ */
+resolve_fn = function(batch) {
+  this.is_pending = false;
+  batch.transfer_effects(__privateGet(this, _dirty_effects2), __privateGet(this, _maybe_dirty_effects2));
+};
+/**
+ * @template T
+ * @param {() => T} fn
+ */
+run_fn = function(fn) {
+  var previous_effect = active_effect;
+  var previous_reaction = active_reaction;
+  var previous_ctx = component_context;
+  set_active_effect(__privateGet(this, _effect));
+  set_active_reaction(__privateGet(this, _effect));
+  set_component_context(__privateGet(this, _effect).ctx);
+  try {
+    Batch.ensure();
+    return fn();
+  } catch (e) {
+    handle_error(e);
+    return null;
+  } finally {
+    set_active_effect(previous_effect);
+    set_active_reaction(previous_reaction);
+    set_component_context(previous_ctx);
+  }
+};
+/**
+ * Updates the pending count associated with the currently visible pending snippet,
+ * if any, such that we can replace the snippet with content once work is done
+ * @param {1 | -1} d
+ * @param {Batch} batch
+ */
+update_pending_count_fn = function(d, batch) {
+  var _a5;
+  if (!this.has_pending_snippet()) {
+    if (this.parent) {
+      __privateMethod(_a5 = this.parent, _Boundary_instances, update_pending_count_fn).call(_a5, d, batch);
+    }
+    return;
+  }
+  __privateSet(this, _pending_count, __privateGet(this, _pending_count) + d);
+  if (__privateGet(this, _pending_count) === 0) {
+    __privateMethod(this, _Boundary_instances, resolve_fn).call(this, batch);
+    if (__privateGet(this, _pending_effect)) {
+      pause_effect(__privateGet(this, _pending_effect), () => {
+        __privateSet(this, _pending_effect, null);
+      });
+    }
+    if (__privateGet(this, _offscreen_fragment)) {
+      __privateGet(this, _anchor).before(__privateGet(this, _offscreen_fragment));
+      __privateSet(this, _offscreen_fragment, null);
+    }
+  }
+};
+/**
+ * @param {unknown} error
+ */
+handle_error_fn = function(error) {
+  if (__privateGet(this, _main_effect)) {
+    destroy_effect(__privateGet(this, _main_effect));
+    __privateSet(this, _main_effect, null);
+  }
+  if (__privateGet(this, _pending_effect)) {
+    destroy_effect(__privateGet(this, _pending_effect));
+    __privateSet(this, _pending_effect, null);
+  }
+  if (__privateGet(this, _failed_effect)) {
+    destroy_effect(__privateGet(this, _failed_effect));
+    __privateSet(this, _failed_effect, null);
+  }
+  if (hydrating) {
+    set_hydrate_node(
+      /** @type {TemplateNode} */
+      __privateGet(this, _hydrate_open)
+    );
+    next();
+    set_hydrate_node(skip_nodes());
+  }
+  var onerror = __privateGet(this, _props).onerror;
+  let failed = __privateGet(this, _props).failed;
+  var did_reset = false;
+  var calling_on_error = false;
+  const reset2 = () => {
+    if (did_reset) {
+      svelte_boundary_reset_noop();
+      return;
+    }
+    did_reset = true;
+    if (calling_on_error) {
+      svelte_boundary_reset_onerror();
+    }
+    if (__privateGet(this, _failed_effect) !== null) {
+      pause_effect(__privateGet(this, _failed_effect), () => {
+        __privateSet(this, _failed_effect, null);
+      });
+    }
+    __privateMethod(this, _Boundary_instances, run_fn).call(this, () => {
+      __privateMethod(this, _Boundary_instances, render_fn).call(this);
+    });
+  };
+  const handle_error_result = (transformed_error) => {
+    try {
+      calling_on_error = true;
+      onerror == null ? void 0 : onerror(transformed_error, reset2);
+      calling_on_error = false;
+    } catch (error2) {
+      invoke_error_boundary(error2, __privateGet(this, _effect) && __privateGet(this, _effect).parent);
+    }
+    if (failed) {
+      __privateSet(this, _failed_effect, __privateMethod(this, _Boundary_instances, run_fn).call(this, () => {
+        try {
+          return branch(() => {
+            var effect2 = (
+              /** @type {Effect} */
+              active_effect
+            );
+            effect2.b = this;
+            effect2.f |= BOUNDARY_EFFECT;
+            failed(
+              __privateGet(this, _anchor),
+              () => transformed_error,
+              () => reset2
+            );
+          });
+        } catch (error2) {
+          invoke_error_boundary(
+            error2,
+            /** @type {Effect} */
+            __privateGet(this, _effect).parent
+          );
+          return null;
+        }
+      }));
+    }
+  };
+  queue_micro_task(() => {
+    var result;
+    try {
+      result = this.transform_error(error);
+    } catch (e) {
+      invoke_error_boundary(e, __privateGet(this, _effect) && __privateGet(this, _effect).parent);
+      return;
+    }
+    if (result !== null && typeof result === "object" && typeof /** @type {any} */
+    result.then === "function") {
+      result.then(
+        handle_error_result,
+        /** @param {unknown} e */
+        (e) => invoke_error_boundary(e, __privateGet(this, _effect) && __privateGet(this, _effect).parent)
+      );
+    } else {
+      handle_error_result(result);
+    }
+  });
+};
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/reactivity/async.js
+function flatten(blockers, sync, async2, fn) {
+  const d = is_runes() ? derived : derived_safe_equal;
+  var pending2 = blockers.filter((b) => !b.settled);
+  if (async2.length === 0 && pending2.length === 0) {
+    fn(sync.map(d));
+    return;
+  }
+  var parent = (
+    /** @type {Effect} */
+    active_effect
+  );
+  var restore = capture();
+  var blocker_promise = pending2.length === 1 ? pending2[0].promise : pending2.length > 1 ? Promise.all(pending2.map((b) => b.promise)) : null;
+  function finish(values) {
+    restore();
+    try {
+      fn(values);
+    } catch (error) {
+      if ((parent.f & DESTROYED) === 0) {
+        invoke_error_boundary(error, parent);
+      }
+    }
+    unset_context();
+  }
+  if (async2.length === 0) {
+    blocker_promise.then(() => finish(sync.map(d)));
+    return;
+  }
+  var decrement_pending = increment_pending();
+  function run3() {
+    Promise.all(async2.map((expression) => async_derived(expression))).then((result) => finish([...sync.map(d), ...result])).catch((error) => invoke_error_boundary(error, parent)).finally(() => decrement_pending());
+  }
+  if (blocker_promise) {
+    blocker_promise.then(() => {
+      restore();
+      run3();
+      unset_context();
+    });
+  } else {
+    run3();
+  }
+}
+function capture() {
+  var previous_effect = (
+    /** @type {Effect} */
+    active_effect
+  );
+  var previous_reaction = active_reaction;
+  var previous_component_context = component_context;
+  var previous_batch2 = (
+    /** @type {Batch} */
+    current_batch
+  );
+  if (dev_fallback_default) {
+    var previous_dev_stack = dev_stack;
+  }
+  return function restore(activate_batch = true) {
+    set_active_effect(previous_effect);
+    set_active_reaction(previous_reaction);
+    set_component_context(previous_component_context);
+    if (activate_batch && (previous_effect.f & DESTROYED) === 0) {
+      previous_batch2 == null ? void 0 : previous_batch2.activate();
+      previous_batch2 == null ? void 0 : previous_batch2.apply();
+    }
+    if (dev_fallback_default) {
+      set_reactivity_loss_tracker(null);
+      set_dev_stack(previous_dev_stack);
+    }
+  };
+}
+function unset_context(deactivate_batch = true) {
+  var _a5;
+  set_active_effect(null);
+  set_active_reaction(null);
+  set_component_context(null);
+  if (deactivate_batch) (_a5 = current_batch) == null ? void 0 : _a5.deactivate();
+  if (dev_fallback_default) {
+    set_reactivity_loss_tracker(null);
+    set_dev_stack(null);
+  }
+}
+function increment_pending() {
+  var effect2 = (
+    /** @type {Effect} */
+    active_effect
+  );
+  var boundary2 = (
+    /** @type {Boundary} */
+    effect2.b
+  );
+  var batch = (
+    /** @type {Batch} */
+    current_batch
+  );
+  var blocking = boundary2.is_rendered();
+  boundary2.update_pending_count(1, batch);
+  batch.increment(blocking, effect2);
+  return (skip = false) => {
+    boundary2.update_pending_count(-1, batch);
+    batch.decrement(blocking, effect2, skip);
+  };
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/reactivity/deriveds.js
+var reactivity_loss_tracker = null;
+function set_reactivity_loss_tracker(v) {
+  reactivity_loss_tracker = v;
+}
+var recent_async_deriveds = /* @__PURE__ */ new Set();
+// @__NO_SIDE_EFFECTS__
+function derived(fn) {
+  var flags2 = DERIVED | DIRTY;
+  if (active_effect !== null) {
+    active_effect.f |= EFFECT_PRESERVED;
+  }
+  const signal = {
+    ctx: component_context,
+    deps: null,
+    effects: null,
+    equals,
+    f: flags2,
+    fn,
+    reactions: null,
+    rv: 0,
+    v: (
+      /** @type {V} */
+      UNINITIALIZED
+    ),
+    wv: 0,
+    parent: active_effect,
+    ac: null
+  };
+  if (dev_fallback_default && tracing_mode_flag) {
+    signal.created = get_error("created at");
+  }
+  return signal;
+}
+// @__NO_SIDE_EFFECTS__
+function async_derived(fn, label, location) {
+  let parent = (
+    /** @type {Effect | null} */
+    active_effect
+  );
+  if (parent === null) {
+    async_derived_orphan();
+  }
+  var promise = (
+    /** @type {Promise<V>} */
+    /** @type {unknown} */
+    void 0
+  );
+  var signal = source(
+    /** @type {V} */
+    UNINITIALIZED
+  );
+  if (dev_fallback_default) signal.label = label;
+  var should_suspend = !active_reaction;
+  var deferreds = /* @__PURE__ */ new Map();
+  async_effect(() => {
+    var _a5;
+    var effect2 = (
+      /** @type {Effect} */
+      active_effect
+    );
+    if (dev_fallback_default) {
+      reactivity_loss_tracker = { effect: effect2, effect_deps: /* @__PURE__ */ new Set(), warned: false };
+    }
+    var d = deferred();
+    promise = d.promise;
+    try {
+      Promise.resolve(fn()).then(d.resolve, d.reject).finally(unset_context);
+    } catch (error) {
+      d.reject(error);
+      unset_context();
+    }
+    if (dev_fallback_default) {
+      if (reactivity_loss_tracker) {
+        if (effect2.deps !== null) {
+          for (let i = 0; i < skipped_deps; i += 1) {
+            reactivity_loss_tracker.effect_deps.add(effect2.deps[i]);
+          }
+        }
+        if (new_deps !== null) {
+          for (let i = 0; i < new_deps.length; i += 1) {
+            reactivity_loss_tracker.effect_deps.add(new_deps[i]);
+          }
+        }
+      }
+      reactivity_loss_tracker = null;
+    }
+    var batch = (
+      /** @type {Batch} */
+      current_batch
+    );
+    if (should_suspend) {
+      if ((effect2.f & REACTION_RAN) !== 0) {
+        var decrement_pending = increment_pending();
+      }
+      if (
+        /** @type {Boundary} */
+        parent.b.is_rendered()
+      ) {
+        (_a5 = deferreds.get(batch)) == null ? void 0 : _a5.reject(STALE_REACTION);
+        deferreds.delete(batch);
+      } else {
+        for (const d2 of deferreds.values()) {
+          d2.reject(STALE_REACTION);
+        }
+        deferreds.clear();
+      }
+      deferreds.set(batch, d);
+    }
+    const handler = (value, error = void 0) => {
+      if (dev_fallback_default) {
+        reactivity_loss_tracker = null;
+      }
+      if (decrement_pending) {
+        var skip = error === STALE_REACTION;
+        decrement_pending(skip);
+      }
+      if (error === STALE_REACTION || (effect2.f & DESTROYED) !== 0) {
+        return;
+      }
+      batch.activate();
+      if (error) {
+        signal.f |= ERROR_VALUE;
+        internal_set(signal, error);
+      } else {
+        if ((signal.f & ERROR_VALUE) !== 0) {
+          signal.f ^= ERROR_VALUE;
+        }
+        internal_set(signal, value);
+        for (const [b, d2] of deferreds) {
+          deferreds.delete(b);
+          if (b === batch) break;
+          d2.reject(STALE_REACTION);
+        }
+        if (dev_fallback_default && location !== void 0) {
+          recent_async_deriveds.add(signal);
+          setTimeout(() => {
+            if (recent_async_deriveds.has(signal)) {
+              await_waterfall(
+                /** @type {string} */
+                signal.label,
+                location
+              );
+              recent_async_deriveds.delete(signal);
+            }
+          });
+        }
+      }
+      batch.deactivate();
+    };
+    d.promise.then(handler, (e) => handler(null, e || "unknown"));
+  });
+  teardown(() => {
+    for (const d of deferreds.values()) {
+      d.reject(STALE_REACTION);
+    }
+  });
+  if (dev_fallback_default) {
+    signal.f |= ASYNC;
+  }
+  return new Promise((fulfil) => {
+    function next2(p) {
+      function go() {
+        if (p === promise) {
+          fulfil(signal);
+        } else {
+          next2(promise);
+        }
+      }
+      p.then(go, go);
+    }
+    next2(promise);
+  });
+}
+// @__NO_SIDE_EFFECTS__
+function user_derived(fn) {
+  const d = /* @__PURE__ */ derived(fn);
+  if (!async_mode_flag) push_reaction_value(d);
+  return d;
+}
+// @__NO_SIDE_EFFECTS__
+function derived_safe_equal(fn) {
+  const signal = /* @__PURE__ */ derived(fn);
+  signal.equals = safe_equals;
+  return signal;
+}
+function destroy_derived_effects(derived2) {
+  var effects = derived2.effects;
+  if (effects !== null) {
+    derived2.effects = null;
+    for (var i = 0; i < effects.length; i += 1) {
+      destroy_effect(
+        /** @type {Effect} */
+        effects[i]
+      );
+    }
+  }
+}
+var stack = [];
+function execute_derived(derived2) {
+  var value;
+  var prev_active_effect = active_effect;
+  var parent = derived2.parent;
+  if (!is_destroying_effect && parent !== null && (parent.f & (DESTROYED | INERT)) !== 0) {
+    derived_inert();
+    return derived2.v;
+  }
+  set_active_effect(parent);
+  if (dev_fallback_default) {
+    let prev_eager_effects = eager_effects;
+    set_eager_effects(/* @__PURE__ */ new Set());
+    try {
+      if (includes.call(stack, derived2)) {
+        derived_references_self();
+      }
+      stack.push(derived2);
+      derived2.f &= ~WAS_MARKED;
+      destroy_derived_effects(derived2);
+      value = update_reaction(derived2);
+    } finally {
+      set_active_effect(prev_active_effect);
+      set_eager_effects(prev_eager_effects);
+      stack.pop();
+    }
+  } else {
+    try {
+      derived2.f &= ~WAS_MARKED;
+      destroy_derived_effects(derived2);
+      value = update_reaction(derived2);
+    } finally {
+      set_active_effect(prev_active_effect);
+    }
+  }
+  return value;
+}
+function update_derived(derived2) {
+  var _a5, _b3;
+  var value = execute_derived(derived2);
+  if (!derived2.equals(value)) {
+    derived2.wv = increment_write_version();
+    if (!((_a5 = current_batch) == null ? void 0 : _a5.is_fork) || derived2.deps === null) {
+      if (current_batch !== null) {
+        current_batch.capture(derived2, value, true);
+      } else {
+        derived2.v = value;
+      }
+      if (derived2.deps === null) {
+        set_signal_status(derived2, CLEAN);
+        return;
+      }
+    }
+  }
+  if (is_destroying_effect) {
+    return;
+  }
+  if (batch_values !== null) {
+    if (effect_tracking() || ((_b3 = current_batch) == null ? void 0 : _b3.is_fork)) {
+      batch_values.set(derived2, value);
+    }
+  } else {
+    update_derived_status(derived2);
+  }
+}
+function freeze_derived_effects(derived2) {
+  var _a5, _b3;
+  if (derived2.effects === null) return;
+  for (const e of derived2.effects) {
+    if (e.teardown || e.ac) {
+      (_a5 = e.teardown) == null ? void 0 : _a5.call(e);
+      (_b3 = e.ac) == null ? void 0 : _b3.abort(STALE_REACTION);
+      e.teardown = noop;
+      e.ac = null;
+      remove_reactions(e, 0);
+      destroy_effect_children(e);
+    }
+  }
+}
+function unfreeze_derived_effects(derived2) {
+  if (derived2.effects === null) return;
+  for (const e of derived2.effects) {
+    if (e.teardown) {
+      update_effect(e);
+    }
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/reactivity/sources.js
+var eager_effects = /* @__PURE__ */ new Set();
+var old_values = /* @__PURE__ */ new Map();
+function set_eager_effects(v) {
+  eager_effects = v;
+}
+var eager_effects_deferred = false;
+function set_eager_effects_deferred() {
+  eager_effects_deferred = true;
+}
+function source(v, stack2) {
+  var signal = {
+    f: 0,
+    // TODO ideally we could skip this altogether, but it causes type errors
+    v,
+    reactions: null,
+    equals,
+    rv: 0,
+    wv: 0
+  };
+  if (dev_fallback_default && tracing_mode_flag) {
+    signal.created = stack2 != null ? stack2 : get_error("created at");
+    signal.updated = null;
+    signal.set_during_effect = false;
+    signal.trace = null;
+  }
+  return signal;
+}
+// @__NO_SIDE_EFFECTS__
+function state(v, stack2) {
+  const s = source(v, stack2);
+  push_reaction_value(s);
+  return s;
+}
+// @__NO_SIDE_EFFECTS__
+function mutable_source(initial_value, immutable = false, trackable = true) {
+  var _a5, _b3;
+  const s = source(initial_value);
+  if (!immutable) {
+    s.equals = safe_equals;
+  }
+  if (legacy_mode_flag && trackable && component_context !== null && component_context.l !== null) {
+    ((_b3 = (_a5 = component_context.l).s) != null ? _b3 : _a5.s = []).push(s);
+  }
+  return s;
+}
+function set(source2, value, should_proxy = false) {
+  if (active_reaction !== null && // since we are untracking the function inside `$inspect.with` we need to add this check
+  // to ensure we error if state is set inside an inspect effect
+  (!untracking || (active_reaction.f & EAGER_EFFECT) !== 0) && is_runes() && (active_reaction.f & (DERIVED | BLOCK_EFFECT | ASYNC | EAGER_EFFECT)) !== 0 && (current_sources === null || !includes.call(current_sources, source2))) {
+    state_unsafe_mutation();
+  }
+  let new_value = should_proxy ? proxy(value) : value;
+  if (dev_fallback_default) {
+    tag_proxy(
+      new_value,
+      /** @type {string} */
+      source2.label
+    );
+  }
+  return internal_set(source2, new_value, legacy_updates);
+}
+function internal_set(source2, value, updated_during_traversal = null) {
+  var _a5, _b3, _c2;
+  if (!source2.equals(value)) {
+    old_values.set(source2, is_destroying_effect ? value : source2.v);
+    var batch = Batch.ensure();
+    batch.capture(source2, value);
+    if (dev_fallback_default) {
+      if (tracing_mode_flag || active_effect !== null) {
+        (_a5 = source2.updated) != null ? _a5 : source2.updated = /* @__PURE__ */ new Map();
+        const count = ((_c2 = (_b3 = source2.updated.get("")) == null ? void 0 : _b3.count) != null ? _c2 : 0) + 1;
+        source2.updated.set("", { error: (
+          /** @type {any} */
+          null
+        ), count });
+        if (tracing_mode_flag || count > 5) {
+          const error = get_error("updated at");
+          if (error !== null) {
+            let entry = source2.updated.get(error.stack);
+            if (!entry) {
+              entry = { error, count: 0 };
+              source2.updated.set(error.stack, entry);
+            }
+            entry.count++;
+          }
+        }
+      }
+      if (active_effect !== null) {
+        source2.set_during_effect = true;
+      }
+    }
+    if ((source2.f & DERIVED) !== 0) {
+      const derived2 = (
+        /** @type {Derived} */
+        source2
+      );
+      if ((source2.f & DIRTY) !== 0) {
+        execute_derived(derived2);
+      }
+      if (batch_values === null) {
+        update_derived_status(derived2);
+      }
+    }
+    source2.wv = increment_write_version();
+    mark_reactions(source2, DIRTY, updated_during_traversal);
+    if (is_runes() && active_effect !== null && (active_effect.f & CLEAN) !== 0 && (active_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0) {
+      if (untracked_writes === null) {
+        set_untracked_writes([source2]);
+      } else {
+        untracked_writes.push(source2);
+      }
+    }
+    if (!batch.is_fork && eager_effects.size > 0 && !eager_effects_deferred) {
+      flush_eager_effects();
+    }
+  }
+  return value;
+}
+function flush_eager_effects() {
+  eager_effects_deferred = false;
+  for (const effect2 of eager_effects) {
+    if ((effect2.f & CLEAN) !== 0) {
+      set_signal_status(effect2, MAYBE_DIRTY);
+    }
+    if (is_dirty(effect2)) {
+      update_effect(effect2);
+    }
+  }
+  eager_effects.clear();
+}
+function increment(source2) {
+  set(source2, source2.v + 1);
+}
+function mark_reactions(signal, status, updated_during_traversal) {
+  var _a5;
+  var reactions = signal.reactions;
+  if (reactions === null) return;
+  var runes = is_runes();
+  var length = reactions.length;
+  for (var i = 0; i < length; i++) {
+    var reaction = reactions[i];
+    var flags2 = reaction.f;
+    if (!runes && reaction === active_effect) continue;
+    if (dev_fallback_default && (flags2 & EAGER_EFFECT) !== 0) {
+      eager_effects.add(reaction);
+      continue;
+    }
+    var not_dirty = (flags2 & DIRTY) === 0;
+    if (not_dirty) {
+      set_signal_status(reaction, status);
+    }
+    if ((flags2 & DERIVED) !== 0) {
+      var derived2 = (
+        /** @type {Derived} */
+        reaction
+      );
+      (_a5 = batch_values) == null ? void 0 : _a5.delete(derived2);
+      if ((flags2 & WAS_MARKED) === 0) {
+        if (flags2 & CONNECTED) {
+          reaction.f |= WAS_MARKED;
+        }
+        mark_reactions(derived2, MAYBE_DIRTY, updated_during_traversal);
+      }
+    } else if (not_dirty) {
+      var effect2 = (
+        /** @type {Effect} */
+        reaction
+      );
+      if ((flags2 & BLOCK_EFFECT) !== 0 && eager_block_effects !== null) {
+        eager_block_effects.add(effect2);
+      }
+      if (updated_during_traversal !== null) {
+        updated_during_traversal.push(effect2);
+      } else {
+        schedule_effect(effect2);
+      }
+    }
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/proxy.js
+var regex_is_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
+function proxy(value) {
+  if (typeof value !== "object" || value === null || STATE_SYMBOL in value) {
+    return value;
+  }
+  const prototype = get_prototype_of(value);
+  if (prototype !== object_prototype && prototype !== array_prototype) {
+    return value;
+  }
+  var sources = /* @__PURE__ */ new Map();
+  var is_proxied_array = is_array(value);
+  var version = state(0);
+  var stack2 = dev_fallback_default && tracing_mode_flag ? get_error("created at") : null;
+  var parent_version = update_version;
+  var with_parent = (fn) => {
+    if (update_version === parent_version) {
+      return fn();
+    }
+    var reaction = active_reaction;
+    var version2 = update_version;
+    set_active_reaction(null);
+    set_update_version(parent_version);
+    var result = fn();
+    set_active_reaction(reaction);
+    set_update_version(version2);
+    return result;
+  };
+  if (is_proxied_array) {
+    sources.set("length", state(
+      /** @type {any[]} */
+      value.length,
+      stack2
+    ));
+    if (dev_fallback_default) {
+      value = /** @type {any} */
+      inspectable_array(
+        /** @type {any[]} */
+        value
+      );
+    }
+  }
+  var path = "";
+  let updating = false;
+  function update_path(new_path) {
+    if (updating) return;
+    updating = true;
+    path = new_path;
+    tag(version, `${path} version`);
+    for (const [prop2, source2] of sources) {
+      tag(source2, get_label(path, prop2));
+    }
+    updating = false;
+  }
+  return new Proxy(
+    /** @type {any} */
+    value,
+    {
+      defineProperty(_, prop2, descriptor) {
+        if (!("value" in descriptor) || descriptor.configurable === false || descriptor.enumerable === false || descriptor.writable === false) {
+          state_descriptors_fixed();
+        }
+        var s = sources.get(prop2);
+        if (s === void 0) {
+          with_parent(() => {
+            var s2 = state(descriptor.value, stack2);
+            sources.set(prop2, s2);
+            if (dev_fallback_default && typeof prop2 === "string") {
+              tag(s2, get_label(path, prop2));
+            }
+            return s2;
+          });
+        } else {
+          set(s, descriptor.value, true);
+        }
+        return true;
+      },
+      deleteProperty(target, prop2) {
+        var s = sources.get(prop2);
+        if (s === void 0) {
+          if (prop2 in target) {
+            const s2 = with_parent(() => state(UNINITIALIZED, stack2));
+            sources.set(prop2, s2);
+            increment(version);
+            if (dev_fallback_default) {
+              tag(s2, get_label(path, prop2));
+            }
+          }
+        } else {
+          set(s, UNINITIALIZED);
+          increment(version);
+        }
+        return true;
+      },
+      get(target, prop2, receiver) {
+        var _a5;
+        if (prop2 === STATE_SYMBOL) {
+          return value;
+        }
+        if (dev_fallback_default && prop2 === PROXY_PATH_SYMBOL) {
+          return update_path;
+        }
+        var s = sources.get(prop2);
+        var exists = prop2 in target;
+        if (s === void 0 && (!exists || ((_a5 = get_descriptor(target, prop2)) == null ? void 0 : _a5.writable))) {
+          s = with_parent(() => {
+            var p = proxy(exists ? target[prop2] : UNINITIALIZED);
+            var s2 = state(p, stack2);
+            if (dev_fallback_default) {
+              tag(s2, get_label(path, prop2));
+            }
+            return s2;
+          });
+          sources.set(prop2, s);
+        }
+        if (s !== void 0) {
+          var v = get2(s);
+          return v === UNINITIALIZED ? void 0 : v;
+        }
+        return Reflect.get(target, prop2, receiver);
+      },
+      getOwnPropertyDescriptor(target, prop2) {
+        var descriptor = Reflect.getOwnPropertyDescriptor(target, prop2);
+        if (descriptor && "value" in descriptor) {
+          var s = sources.get(prop2);
+          if (s) descriptor.value = get2(s);
+        } else if (descriptor === void 0) {
+          var source2 = sources.get(prop2);
+          var value2 = source2 == null ? void 0 : source2.v;
+          if (source2 !== void 0 && value2 !== UNINITIALIZED) {
+            return {
+              enumerable: true,
+              configurable: true,
+              value: value2,
+              writable: true
+            };
+          }
+        }
+        return descriptor;
+      },
+      has(target, prop2) {
+        var _a5;
+        if (prop2 === STATE_SYMBOL) {
+          return true;
+        }
+        var s = sources.get(prop2);
+        var has = s !== void 0 && s.v !== UNINITIALIZED || Reflect.has(target, prop2);
+        if (s !== void 0 || active_effect !== null && (!has || ((_a5 = get_descriptor(target, prop2)) == null ? void 0 : _a5.writable))) {
+          if (s === void 0) {
+            s = with_parent(() => {
+              var p = has ? proxy(target[prop2]) : UNINITIALIZED;
+              var s2 = state(p, stack2);
+              if (dev_fallback_default) {
+                tag(s2, get_label(path, prop2));
+              }
+              return s2;
+            });
+            sources.set(prop2, s);
+          }
+          var value2 = get2(s);
+          if (value2 === UNINITIALIZED) {
+            return false;
+          }
+        }
+        return has;
+      },
+      set(target, prop2, value2, receiver) {
+        var _a5;
+        var s = sources.get(prop2);
+        var has = prop2 in target;
+        if (is_proxied_array && prop2 === "length") {
+          for (var i = value2; i < /** @type {Source<number>} */
+          s.v; i += 1) {
+            var other_s = sources.get(i + "");
+            if (other_s !== void 0) {
+              set(other_s, UNINITIALIZED);
+            } else if (i in target) {
+              other_s = with_parent(() => state(UNINITIALIZED, stack2));
+              sources.set(i + "", other_s);
+              if (dev_fallback_default) {
+                tag(other_s, get_label(path, i));
+              }
+            }
+          }
+        }
+        if (s === void 0) {
+          if (!has || ((_a5 = get_descriptor(target, prop2)) == null ? void 0 : _a5.writable)) {
+            s = with_parent(() => state(void 0, stack2));
+            if (dev_fallback_default) {
+              tag(s, get_label(path, prop2));
+            }
+            set(s, proxy(value2));
+            sources.set(prop2, s);
+          }
+        } else {
+          has = s.v !== UNINITIALIZED;
+          var p = with_parent(() => proxy(value2));
+          set(s, p);
+        }
+        var descriptor = Reflect.getOwnPropertyDescriptor(target, prop2);
+        if (descriptor == null ? void 0 : descriptor.set) {
+          descriptor.set.call(receiver, value2);
+        }
+        if (!has) {
+          if (is_proxied_array && typeof prop2 === "string") {
+            var ls = (
+              /** @type {Source<number>} */
+              sources.get("length")
+            );
+            var n = Number(prop2);
+            if (Number.isInteger(n) && n >= ls.v) {
+              set(ls, n + 1);
+            }
+          }
+          increment(version);
+        }
+        return true;
+      },
+      ownKeys(target) {
+        get2(version);
+        var own_keys = Reflect.ownKeys(target).filter((key3) => {
+          var source3 = sources.get(key3);
+          return source3 === void 0 || source3.v !== UNINITIALIZED;
+        });
+        for (var [key2, source2] of sources) {
+          if (source2.v !== UNINITIALIZED && !(key2 in target)) {
+            own_keys.push(key2);
+          }
+        }
+        return own_keys;
+      },
+      setPrototypeOf() {
+        state_prototype_fixed();
+      }
+    }
+  );
+}
+function get_label(path, prop2) {
+  var _a5;
+  if (typeof prop2 === "symbol") return `${path}[Symbol(${(_a5 = prop2.description) != null ? _a5 : ""})]`;
+  if (regex_is_valid_identifier.test(prop2)) return `${path}.${prop2}`;
+  return /^\d+$/.test(prop2) ? `${path}[${prop2}]` : `${path}['${prop2}']`;
+}
+function get_proxied_value(value) {
+  try {
+    if (value !== null && typeof value === "object" && STATE_SYMBOL in value) {
+      return value[STATE_SYMBOL];
+    }
+  } catch (e) {
+  }
+  return value;
+}
+var ARRAY_MUTATING_METHODS = /* @__PURE__ */ new Set([
+  "copyWithin",
+  "fill",
+  "pop",
+  "push",
+  "reverse",
+  "shift",
+  "sort",
+  "splice",
+  "unshift"
+]);
+function inspectable_array(array) {
+  return new Proxy(array, {
+    get(target, prop2, receiver) {
+      var value = Reflect.get(target, prop2, receiver);
+      if (!ARRAY_MUTATING_METHODS.has(
+        /** @type {string} */
+        prop2
+      )) {
+        return value;
+      }
+      return function(...args) {
+        set_eager_effects_deferred();
+        var result = value.apply(this, args);
+        flush_eager_effects();
+        return result;
+      };
+    }
+  });
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dev/equality.js
+function init_array_prototype_warnings() {
+  const array_prototype2 = Array.prototype;
+  const cleanup = Array.__svelte_cleanup;
+  if (cleanup) {
+    cleanup();
+  }
+  const { indexOf, lastIndexOf, includes: includes2 } = array_prototype2;
+  array_prototype2.indexOf = function(item, from_index) {
+    const index2 = indexOf.call(this, item, from_index);
+    if (index2 === -1) {
+      for (let i = from_index != null ? from_index : 0; i < this.length; i += 1) {
+        if (get_proxied_value(this[i]) === item) {
+          state_proxy_equality_mismatch("array.indexOf(...)");
+          break;
+        }
+      }
+    }
+    return index2;
+  };
+  array_prototype2.lastIndexOf = function(item, from_index) {
+    const index2 = lastIndexOf.call(this, item, from_index != null ? from_index : this.length - 1);
+    if (index2 === -1) {
+      for (let i = 0; i <= (from_index != null ? from_index : this.length - 1); i += 1) {
+        if (get_proxied_value(this[i]) === item) {
+          state_proxy_equality_mismatch("array.lastIndexOf(...)");
+          break;
+        }
+      }
+    }
+    return index2;
+  };
+  array_prototype2.includes = function(item, from_index) {
+    const has = includes2.call(this, item, from_index);
+    if (!has) {
+      for (let i = 0; i < this.length; i += 1) {
+        if (get_proxied_value(this[i]) === item) {
+          state_proxy_equality_mismatch("array.includes(...)");
+          break;
+        }
+      }
+    }
+    return has;
+  };
+  Array.__svelte_cleanup = () => {
+    array_prototype2.indexOf = indexOf;
+    array_prototype2.lastIndexOf = lastIndexOf;
+    array_prototype2.includes = includes2;
+  };
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/operations.js
+var $window;
+var $document;
+var is_firefox;
+var first_child_getter;
+var next_sibling_getter;
+function init_operations() {
+  if ($window !== void 0) {
+    return;
+  }
+  $window = window;
+  $document = document;
+  is_firefox = /Firefox/.test(navigator.userAgent);
+  var element_prototype = Element.prototype;
+  var node_prototype = Node.prototype;
+  var text_prototype = Text.prototype;
+  first_child_getter = get_descriptor(node_prototype, "firstChild").get;
+  next_sibling_getter = get_descriptor(node_prototype, "nextSibling").get;
+  if (is_extensible(element_prototype)) {
+    element_prototype.__click = void 0;
+    element_prototype.__className = void 0;
+    element_prototype.__attributes = null;
+    element_prototype.__style = void 0;
+    element_prototype.__e = void 0;
+  }
+  if (is_extensible(text_prototype)) {
+    text_prototype.__t = void 0;
+  }
+  if (dev_fallback_default) {
+    element_prototype.__svelte_meta = null;
+    init_array_prototype_warnings();
+  }
+}
+function create_text(value = "") {
+  return document.createTextNode(value);
+}
+// @__NO_SIDE_EFFECTS__
+function get_first_child(node) {
+  return (
+    /** @type {TemplateNode | null} */
+    first_child_getter.call(node)
+  );
+}
+// @__NO_SIDE_EFFECTS__
+function get_next_sibling(node) {
+  return (
+    /** @type {TemplateNode | null} */
+    next_sibling_getter.call(node)
+  );
+}
+function child(node, is_text) {
+  if (!hydrating) {
+    return /* @__PURE__ */ get_first_child(node);
+  }
+  var child2 = /* @__PURE__ */ get_first_child(hydrate_node);
+  if (child2 === null) {
+    child2 = hydrate_node.appendChild(create_text());
+  } else if (is_text && child2.nodeType !== TEXT_NODE) {
+    var text2 = create_text();
+    child2 == null ? void 0 : child2.before(text2);
+    set_hydrate_node(text2);
+    return text2;
+  }
+  if (is_text) {
+    merge_text_nodes(
+      /** @type {Text} */
+      child2
+    );
+  }
+  set_hydrate_node(child2);
+  return child2;
+}
+function sibling(node, count = 1, is_text = false) {
+  let next_sibling = hydrating ? hydrate_node : node;
+  var last_sibling;
+  while (count--) {
+    last_sibling = next_sibling;
+    next_sibling = /** @type {TemplateNode} */
+    /* @__PURE__ */ get_next_sibling(next_sibling);
+  }
+  if (!hydrating) {
+    return next_sibling;
+  }
+  if (is_text) {
+    if ((next_sibling == null ? void 0 : next_sibling.nodeType) !== TEXT_NODE) {
+      var text2 = create_text();
+      if (next_sibling === null) {
+        last_sibling == null ? void 0 : last_sibling.after(text2);
+      } else {
+        next_sibling.before(text2);
+      }
+      set_hydrate_node(text2);
+      return text2;
+    }
+    merge_text_nodes(
+      /** @type {Text} */
+      next_sibling
+    );
+  }
+  set_hydrate_node(next_sibling);
+  return next_sibling;
+}
+function clear_text_content(node) {
+  node.textContent = "";
+}
+function should_defer_append() {
+  if (!async_mode_flag) return false;
+  if (eager_block_effects !== null) return false;
+  var flags2 = (
+    /** @type {Effect} */
+    active_effect.f
+  );
+  return (flags2 & REACTION_RAN) !== 0;
+}
+function create_element(tag2, namespace, is2) {
+  let options = is2 ? { is: is2 } : void 0;
+  return (
+    /** @type {T extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[T] : Element} */
+    document.createElementNS(namespace != null ? namespace : NAMESPACE_HTML, tag2, options)
+  );
+}
+function merge_text_nodes(text2) {
+  if (
+    /** @type {string} */
+    text2.nodeValue.length < 65536
+  ) {
+    return;
+  }
+  let next2 = text2.nextSibling;
+  while (next2 !== null && next2.nodeType === TEXT_NODE) {
+    next2.remove();
+    text2.nodeValue += /** @type {string} */
+    next2.nodeValue;
+    next2 = text2.nextSibling;
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/elements/bindings/shared.js
+function without_reactive_context(fn) {
+  var previous_reaction = active_reaction;
+  var previous_effect = active_effect;
+  set_active_reaction(null);
+  set_active_effect(null);
+  try {
+    return fn();
+  } finally {
+    set_active_reaction(previous_reaction);
+    set_active_effect(previous_effect);
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/reactivity/effects.js
+function push_effect(effect2, parent_effect) {
+  var parent_last = parent_effect.last;
+  if (parent_last === null) {
+    parent_effect.last = parent_effect.first = effect2;
+  } else {
+    parent_last.next = effect2;
+    effect2.prev = parent_last;
+    parent_effect.last = effect2;
+  }
+}
+function create_effect(type, fn) {
+  var _a5, _b3;
+  var parent = active_effect;
+  if (dev_fallback_default) {
+    while (parent !== null && (parent.f & EAGER_EFFECT) !== 0) {
+      parent = parent.parent;
+    }
+  }
+  if (parent !== null && (parent.f & INERT) !== 0) {
+    type |= INERT;
+  }
+  var effect2 = {
+    ctx: component_context,
+    deps: null,
+    nodes: null,
+    f: type | DIRTY | CONNECTED,
+    first: null,
+    fn,
+    last: null,
+    next: null,
+    parent,
+    b: parent && parent.b,
+    prev: null,
+    teardown: null,
+    wv: 0,
+    ac: null
+  };
+  if (dev_fallback_default) {
+    effect2.component_function = dev_current_component_function;
+  }
+  (_a5 = current_batch) == null ? void 0 : _a5.register_created_effect(effect2);
+  var e = effect2;
+  if ((type & EFFECT) !== 0) {
+    if (collected_effects !== null) {
+      collected_effects.push(effect2);
+    } else {
+      Batch.ensure().schedule(effect2);
+    }
+  } else if (fn !== null) {
+    try {
+      update_effect(effect2);
+    } catch (e2) {
+      destroy_effect(effect2);
+      throw e2;
+    }
+    if (e.deps === null && e.teardown === null && e.nodes === null && e.first === e.last && // either `null`, or a singular child
+    (e.f & EFFECT_PRESERVED) === 0) {
+      e = e.first;
+      if ((type & BLOCK_EFFECT) !== 0 && (type & EFFECT_TRANSPARENT) !== 0 && e !== null) {
+        e.f |= EFFECT_TRANSPARENT;
+      }
+    }
+  }
+  if (e !== null) {
+    e.parent = parent;
+    if (parent !== null) {
+      push_effect(e, parent);
+    }
+    if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0 && (type & ROOT_EFFECT) === 0) {
+      var derived2 = (
+        /** @type {Derived} */
+        active_reaction
+      );
+      ((_b3 = derived2.effects) != null ? _b3 : derived2.effects = []).push(e);
+    }
+  }
+  return effect2;
+}
+function effect_tracking() {
+  return active_reaction !== null && !untracking;
+}
+function teardown(fn) {
+  const effect2 = create_effect(RENDER_EFFECT, null);
+  set_signal_status(effect2, CLEAN);
+  effect2.teardown = fn;
+  return effect2;
+}
+function create_user_effect(fn) {
+  return create_effect(EFFECT | USER_EFFECT, fn);
+}
+function effect_root(fn) {
+  Batch.ensure();
+  const effect2 = create_effect(ROOT_EFFECT | EFFECT_PRESERVED, fn);
+  return () => {
+    destroy_effect(effect2);
+  };
+}
+function component_root(fn) {
+  Batch.ensure();
+  const effect2 = create_effect(ROOT_EFFECT | EFFECT_PRESERVED, fn);
+  return (options = {}) => {
+    return new Promise((fulfil) => {
+      if (options.outro) {
+        pause_effect(effect2, () => {
+          destroy_effect(effect2);
+          fulfil(void 0);
+        });
+      } else {
+        destroy_effect(effect2);
+        fulfil(void 0);
+      }
+    });
+  };
+}
+function async_effect(fn) {
+  return create_effect(ASYNC | EFFECT_PRESERVED, fn);
+}
+function render_effect(fn, flags2 = 0) {
+  return create_effect(RENDER_EFFECT | flags2, fn);
+}
+function template_effect(fn, sync = [], async2 = [], blockers = []) {
+  flatten(blockers, sync, async2, (values) => {
+    create_effect(RENDER_EFFECT, () => fn(...values.map(get2)));
+  });
+}
+function block(fn, flags2 = 0) {
+  var effect2 = create_effect(BLOCK_EFFECT | flags2, fn);
+  if (dev_fallback_default) {
+    effect2.dev_stack = dev_stack;
+  }
+  return effect2;
+}
+function branch(fn) {
+  return create_effect(BRANCH_EFFECT | EFFECT_PRESERVED, fn);
+}
+function execute_effect_teardown(effect2) {
+  var teardown2 = effect2.teardown;
+  if (teardown2 !== null) {
+    const previously_destroying_effect = is_destroying_effect;
+    const previous_reaction = active_reaction;
+    set_is_destroying_effect(true);
+    set_active_reaction(null);
+    try {
+      teardown2.call(null);
+    } finally {
+      set_is_destroying_effect(previously_destroying_effect);
+      set_active_reaction(previous_reaction);
+    }
+  }
+}
+function destroy_effect_children(signal, remove_dom = false) {
+  var effect2 = signal.first;
+  signal.first = signal.last = null;
+  while (effect2 !== null) {
+    const controller = effect2.ac;
+    if (controller !== null) {
+      without_reactive_context(() => {
+        controller.abort(STALE_REACTION);
+      });
+    }
+    var next2 = effect2.next;
+    if ((effect2.f & ROOT_EFFECT) !== 0) {
+      effect2.parent = null;
+    } else {
+      destroy_effect(effect2, remove_dom);
+    }
+    effect2 = next2;
+  }
+}
+function destroy_block_effect_children(signal) {
+  var effect2 = signal.first;
+  while (effect2 !== null) {
+    var next2 = effect2.next;
+    if ((effect2.f & BRANCH_EFFECT) === 0) {
+      destroy_effect(effect2);
+    }
+    effect2 = next2;
+  }
+}
+function destroy_effect(effect2, remove_dom = true) {
+  var removed = false;
+  if ((remove_dom || (effect2.f & HEAD_EFFECT) !== 0) && effect2.nodes !== null && effect2.nodes.end !== null) {
+    remove_effect_dom(
+      effect2.nodes.start,
+      /** @type {TemplateNode} */
+      effect2.nodes.end
+    );
+    removed = true;
+  }
+  set_signal_status(effect2, DESTROYING);
+  destroy_effect_children(effect2, remove_dom && !removed);
+  remove_reactions(effect2, 0);
+  var transitions = effect2.nodes && effect2.nodes.t;
+  if (transitions !== null) {
+    for (const transition2 of transitions) {
+      transition2.stop();
+    }
+  }
+  execute_effect_teardown(effect2);
+  effect2.f ^= DESTROYING;
+  effect2.f |= DESTROYED;
+  var parent = effect2.parent;
+  if (parent !== null && parent.first !== null) {
+    unlink_effect(effect2);
+  }
+  if (dev_fallback_default) {
+    effect2.component_function = null;
+  }
+  effect2.next = effect2.prev = effect2.teardown = effect2.ctx = effect2.deps = effect2.fn = effect2.nodes = effect2.ac = effect2.b = null;
+}
+function remove_effect_dom(node, end) {
+  while (node !== null) {
+    var next2 = node === end ? null : get_next_sibling(node);
+    node.remove();
+    node = next2;
+  }
+}
+function unlink_effect(effect2) {
+  var parent = effect2.parent;
+  var prev = effect2.prev;
+  var next2 = effect2.next;
+  if (prev !== null) prev.next = next2;
+  if (next2 !== null) next2.prev = prev;
+  if (parent !== null) {
+    if (parent.first === effect2) parent.first = next2;
+    if (parent.last === effect2) parent.last = prev;
+  }
+}
+function pause_effect(effect2, callback, destroy = true) {
+  var transitions = [];
+  pause_children(effect2, transitions, true);
+  var fn = () => {
+    if (destroy) destroy_effect(effect2);
+    if (callback) callback();
+  };
+  var remaining = transitions.length;
+  if (remaining > 0) {
+    var check = () => --remaining || fn();
+    for (var transition2 of transitions) {
+      transition2.out(check);
+    }
+  } else {
+    fn();
+  }
+}
+function pause_children(effect2, transitions, local) {
+  if ((effect2.f & INERT) !== 0) return;
+  effect2.f ^= INERT;
+  var t = effect2.nodes && effect2.nodes.t;
+  if (t !== null) {
+    for (const transition2 of t) {
+      if (transition2.is_global || local) {
+        transitions.push(transition2);
+      }
+    }
+  }
+  var child2 = effect2.first;
+  while (child2 !== null) {
+    var sibling2 = child2.next;
+    if ((child2.f & ROOT_EFFECT) === 0) {
+      var transparent = (child2.f & EFFECT_TRANSPARENT) !== 0 || // If this is a branch effect without a block effect parent,
+      // it means the parent block effect was pruned. In that case,
+      // transparency information was transferred to the branch effect.
+      (child2.f & BRANCH_EFFECT) !== 0 && (effect2.f & BLOCK_EFFECT) !== 0;
+      pause_children(child2, transitions, transparent ? local : false);
+    }
+    child2 = sibling2;
+  }
+}
+function resume_effect(effect2) {
+  resume_children(effect2, true);
+}
+function resume_children(effect2, local) {
+  if ((effect2.f & INERT) === 0) return;
+  effect2.f ^= INERT;
+  if ((effect2.f & CLEAN) === 0) {
+    set_signal_status(effect2, DIRTY);
+    Batch.ensure().schedule(effect2);
+  }
+  var child2 = effect2.first;
+  while (child2 !== null) {
+    var sibling2 = child2.next;
+    var transparent = (child2.f & EFFECT_TRANSPARENT) !== 0 || (child2.f & BRANCH_EFFECT) !== 0;
+    resume_children(child2, transparent ? local : false);
+    child2 = sibling2;
+  }
+  var t = effect2.nodes && effect2.nodes.t;
+  if (t !== null) {
+    for (const transition2 of t) {
+      if (transition2.is_global || local) {
+        transition2.in();
+      }
+    }
+  }
+}
+function move_effect(effect2, fragment) {
+  if (!effect2.nodes) return;
+  var node = effect2.nodes.start;
+  var end = effect2.nodes.end;
+  while (node !== null) {
+    var next2 = node === end ? null : get_next_sibling(node);
+    fragment.append(node);
+    node = next2;
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/legacy.js
+var captured_signals = null;
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/runtime.js
+var is_updating_effect = false;
+var is_destroying_effect = false;
+function set_is_destroying_effect(value) {
+  is_destroying_effect = value;
+}
+var active_reaction = null;
+var untracking = false;
+function set_active_reaction(reaction) {
+  active_reaction = reaction;
+}
+var active_effect = null;
+function set_active_effect(effect2) {
+  active_effect = effect2;
+}
+var current_sources = null;
+function push_reaction_value(value) {
+  if (active_reaction !== null && (!async_mode_flag || (active_reaction.f & DERIVED) !== 0)) {
+    if (current_sources === null) {
+      current_sources = [value];
+    } else {
+      current_sources.push(value);
+    }
+  }
+}
+var new_deps = null;
+var skipped_deps = 0;
+var untracked_writes = null;
+function set_untracked_writes(value) {
+  untracked_writes = value;
+}
+var write_version = 1;
+var read_version = 0;
+var update_version = read_version;
+function set_update_version(value) {
+  update_version = value;
+}
+function increment_write_version() {
+  return ++write_version;
+}
+function is_dirty(reaction) {
+  var flags2 = reaction.f;
+  if ((flags2 & DIRTY) !== 0) {
+    return true;
+  }
+  if (flags2 & DERIVED) {
+    reaction.f &= ~WAS_MARKED;
+  }
+  if ((flags2 & MAYBE_DIRTY) !== 0) {
+    var dependencies = (
+      /** @type {Value[]} */
+      reaction.deps
+    );
+    var length = dependencies.length;
+    for (var i = 0; i < length; i++) {
+      var dependency = dependencies[i];
+      if (is_dirty(
+        /** @type {Derived} */
+        dependency
+      )) {
+        update_derived(
+          /** @type {Derived} */
+          dependency
+        );
+      }
+      if (dependency.wv > reaction.wv) {
+        return true;
+      }
+    }
+    if ((flags2 & CONNECTED) !== 0 && // During time traveling we don't want to reset the status so that
+    // traversal of the graph in the other batches still happens
+    batch_values === null) {
+      set_signal_status(reaction, CLEAN);
+    }
+  }
+  return false;
+}
+function schedule_possible_effect_self_invalidation(signal, effect2, root3 = true) {
+  var reactions = signal.reactions;
+  if (reactions === null) return;
+  if (!async_mode_flag && current_sources !== null && includes.call(current_sources, signal)) {
+    return;
+  }
+  for (var i = 0; i < reactions.length; i++) {
+    var reaction = reactions[i];
+    if ((reaction.f & DERIVED) !== 0) {
+      schedule_possible_effect_self_invalidation(
+        /** @type {Derived} */
+        reaction,
+        effect2,
+        false
+      );
+    } else if (effect2 === reaction) {
+      if (root3) {
+        set_signal_status(reaction, DIRTY);
+      } else if ((reaction.f & CLEAN) !== 0) {
+        set_signal_status(reaction, MAYBE_DIRTY);
+      }
+      schedule_effect(
+        /** @type {Effect} */
+        reaction
+      );
+    }
+  }
+}
+function update_reaction(reaction) {
+  var _a5, _b3, _c2;
+  var previous_deps = new_deps;
+  var previous_skipped_deps = skipped_deps;
+  var previous_untracked_writes = untracked_writes;
+  var previous_reaction = active_reaction;
+  var previous_sources = current_sources;
+  var previous_component_context = component_context;
+  var previous_untracking = untracking;
+  var previous_update_version = update_version;
+  var flags2 = reaction.f;
+  new_deps = /** @type {null | Value[]} */
+  null;
+  skipped_deps = 0;
+  untracked_writes = null;
+  active_reaction = (flags2 & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 ? reaction : null;
+  current_sources = null;
+  set_component_context(reaction.ctx);
+  untracking = false;
+  update_version = ++read_version;
+  if (reaction.ac !== null) {
+    without_reactive_context(() => {
+      reaction.ac.abort(STALE_REACTION);
+    });
+    reaction.ac = null;
+  }
+  try {
+    reaction.f |= REACTION_IS_UPDATING;
+    var fn = (
+      /** @type {Function} */
+      reaction.fn
+    );
+    var result = fn();
+    reaction.f |= REACTION_RAN;
+    var deps = reaction.deps;
+    var is_fork = (_a5 = current_batch) == null ? void 0 : _a5.is_fork;
+    if (new_deps !== null) {
+      var i;
+      if (!is_fork) {
+        remove_reactions(reaction, skipped_deps);
+      }
+      if (deps !== null && skipped_deps > 0) {
+        deps.length = skipped_deps + new_deps.length;
+        for (i = 0; i < new_deps.length; i++) {
+          deps[skipped_deps + i] = new_deps[i];
+        }
+      } else {
+        reaction.deps = deps = new_deps;
+      }
+      if (effect_tracking() && (reaction.f & CONNECTED) !== 0) {
+        for (i = skipped_deps; i < deps.length; i++) {
+          ((_c2 = (_b3 = deps[i]).reactions) != null ? _c2 : _b3.reactions = []).push(reaction);
+        }
+      }
+    } else if (!is_fork && deps !== null && skipped_deps < deps.length) {
+      remove_reactions(reaction, skipped_deps);
+      deps.length = skipped_deps;
+    }
+    if (is_runes() && untracked_writes !== null && !untracking && deps !== null && (reaction.f & (DERIVED | MAYBE_DIRTY | DIRTY)) === 0) {
+      for (i = 0; i < /** @type {Source[]} */
+      untracked_writes.length; i++) {
+        schedule_possible_effect_self_invalidation(
+          untracked_writes[i],
+          /** @type {Effect} */
+          reaction
+        );
+      }
+    }
+    if (previous_reaction !== null && previous_reaction !== reaction) {
+      read_version++;
+      if (previous_reaction.deps !== null) {
+        for (let i2 = 0; i2 < previous_skipped_deps; i2 += 1) {
+          previous_reaction.deps[i2].rv = read_version;
+        }
+      }
+      if (previous_deps !== null) {
+        for (const dep of previous_deps) {
+          dep.rv = read_version;
+        }
+      }
+      if (untracked_writes !== null) {
+        if (previous_untracked_writes === null) {
+          previous_untracked_writes = untracked_writes;
+        } else {
+          previous_untracked_writes.push(.../** @type {Source[]} */
+          untracked_writes);
+        }
+      }
+    }
+    if ((reaction.f & ERROR_VALUE) !== 0) {
+      reaction.f ^= ERROR_VALUE;
+    }
+    return result;
+  } catch (error) {
+    return handle_error(error);
+  } finally {
+    reaction.f ^= REACTION_IS_UPDATING;
+    new_deps = previous_deps;
+    skipped_deps = previous_skipped_deps;
+    untracked_writes = previous_untracked_writes;
+    active_reaction = previous_reaction;
+    current_sources = previous_sources;
+    set_component_context(previous_component_context);
+    untracking = previous_untracking;
+    update_version = previous_update_version;
+  }
+}
+function remove_reaction(signal, dependency) {
+  let reactions = dependency.reactions;
+  if (reactions !== null) {
+    var index2 = index_of.call(reactions, signal);
+    if (index2 !== -1) {
+      var new_length = reactions.length - 1;
+      if (new_length === 0) {
+        reactions = dependency.reactions = null;
+      } else {
+        reactions[index2] = reactions[new_length];
+        reactions.pop();
+      }
+    }
+  }
+  if (reactions === null && (dependency.f & DERIVED) !== 0 && // Destroying a child effect while updating a parent effect can cause a dependency to appear
+  // to be unused, when in fact it is used by the currently-updating parent. Checking `new_deps`
+  // allows us to skip the expensive work of disconnecting and immediately reconnecting it
+  (new_deps === null || !includes.call(new_deps, dependency))) {
+    var derived2 = (
+      /** @type {Derived} */
+      dependency
+    );
+    if ((derived2.f & CONNECTED) !== 0) {
+      derived2.f ^= CONNECTED;
+      derived2.f &= ~WAS_MARKED;
+    }
+    if (derived2.v !== UNINITIALIZED) {
+      update_derived_status(derived2);
+    }
+    freeze_derived_effects(derived2);
+    remove_reactions(derived2, 0);
+  }
+}
+function remove_reactions(signal, start_index) {
+  var dependencies = signal.deps;
+  if (dependencies === null) return;
+  for (var i = start_index; i < dependencies.length; i++) {
+    remove_reaction(signal, dependencies[i]);
+  }
+}
+function update_effect(effect2) {
+  var _a5;
+  var flags2 = effect2.f;
+  if ((flags2 & DESTROYED) !== 0) {
+    return;
+  }
+  set_signal_status(effect2, CLEAN);
+  var previous_effect = active_effect;
+  var was_updating_effect = is_updating_effect;
+  active_effect = effect2;
+  is_updating_effect = true;
+  if (dev_fallback_default) {
+    var previous_component_fn = dev_current_component_function;
+    set_dev_current_component_function(effect2.component_function);
+    var previous_stack = (
+      /** @type {any} */
+      dev_stack
+    );
+    set_dev_stack((_a5 = effect2.dev_stack) != null ? _a5 : dev_stack);
+  }
+  try {
+    if ((flags2 & (BLOCK_EFFECT | MANAGED_EFFECT)) !== 0) {
+      destroy_block_effect_children(effect2);
+    } else {
+      destroy_effect_children(effect2);
+    }
+    execute_effect_teardown(effect2);
+    var teardown2 = update_reaction(effect2);
+    effect2.teardown = typeof teardown2 === "function" ? teardown2 : null;
+    effect2.wv = write_version;
+    if (dev_fallback_default && tracing_mode_flag && (effect2.f & DIRTY) !== 0 && effect2.deps !== null) {
+      for (var dep of effect2.deps) {
+        if (dep.set_during_effect) {
+          dep.wv = increment_write_version();
+          dep.set_during_effect = false;
+        }
+      }
+    }
+  } finally {
+    is_updating_effect = was_updating_effect;
+    active_effect = previous_effect;
+    if (dev_fallback_default) {
+      set_dev_current_component_function(previous_component_fn);
+      set_dev_stack(previous_stack);
+    }
+  }
+}
+function get2(signal) {
+  var _a5, _b3, _c2;
+  var flags2 = signal.f;
+  var is_derived = (flags2 & DERIVED) !== 0;
+  (_a5 = captured_signals) == null ? void 0 : _a5.add(signal);
+  if (active_reaction !== null && !untracking) {
+    var destroyed = active_effect !== null && (active_effect.f & DESTROYED) !== 0;
+    if (!destroyed && (current_sources === null || !includes.call(current_sources, signal))) {
+      var deps = active_reaction.deps;
+      if ((active_reaction.f & REACTION_IS_UPDATING) !== 0) {
+        if (signal.rv < read_version) {
+          signal.rv = read_version;
+          if (new_deps === null && deps !== null && deps[skipped_deps] === signal) {
+            skipped_deps++;
+          } else if (new_deps === null) {
+            new_deps = [signal];
+          } else {
+            new_deps.push(signal);
+          }
+        }
+      } else {
+        ((_b3 = active_reaction.deps) != null ? _b3 : active_reaction.deps = []).push(signal);
+        var reactions = signal.reactions;
+        if (reactions === null) {
+          signal.reactions = [active_reaction];
+        } else if (!includes.call(reactions, active_reaction)) {
+          reactions.push(active_reaction);
+        }
+      }
+    }
+  }
+  if (dev_fallback_default) {
+    if (!untracking && reactivity_loss_tracker && !reactivity_loss_tracker.warned && (reactivity_loss_tracker.effect.f & REACTION_IS_UPDATING) === 0 && !reactivity_loss_tracker.effect_deps.has(signal)) {
+      reactivity_loss_tracker.warned = true;
+      await_reactivity_loss(
+        /** @type {string} */
+        signal.label
+      );
+      var trace2 = get_error("traced at");
+      if (trace2) console.warn(trace2);
+    }
+    recent_async_deriveds.delete(signal);
+    if (tracing_mode_flag && !untracking && tracing_expressions !== null && active_reaction !== null && tracing_expressions.reaction === active_reaction) {
+      if (signal.trace) {
+        signal.trace();
+      } else {
+        trace2 = get_error("traced at");
+        if (trace2) {
+          var entry = tracing_expressions.entries.get(signal);
+          if (entry === void 0) {
+            entry = { traces: [] };
+            tracing_expressions.entries.set(signal, entry);
+          }
+          var last = entry.traces[entry.traces.length - 1];
+          if (trace2.stack !== (last == null ? void 0 : last.stack)) {
+            entry.traces.push(trace2);
+          }
+        }
+      }
+    }
+  }
+  if (is_destroying_effect && old_values.has(signal)) {
+    return old_values.get(signal);
+  }
+  if (is_derived) {
+    var derived2 = (
+      /** @type {Derived} */
+      signal
+    );
+    if (is_destroying_effect) {
+      var value = derived2.v;
+      if ((derived2.f & CLEAN) === 0 && derived2.reactions !== null || depends_on_old_values(derived2)) {
+        value = execute_derived(derived2);
+      }
+      old_values.set(derived2, value);
+      return value;
+    }
+    var should_connect = (derived2.f & CONNECTED) === 0 && !untracking && active_reaction !== null && (is_updating_effect || (active_reaction.f & CONNECTED) !== 0);
+    var is_new = (derived2.f & REACTION_RAN) === 0;
+    if (is_dirty(derived2)) {
+      if (should_connect) {
+        derived2.f |= CONNECTED;
+      }
+      update_derived(derived2);
+    }
+    if (should_connect && !is_new) {
+      unfreeze_derived_effects(derived2);
+      reconnect(derived2);
+    }
+  }
+  if ((_c2 = batch_values) == null ? void 0 : _c2.has(signal)) {
+    return batch_values.get(signal);
+  }
+  if ((signal.f & ERROR_VALUE) !== 0) {
+    throw signal.v;
+  }
+  return signal.v;
+}
+function reconnect(derived2) {
+  var _a5;
+  derived2.f |= CONNECTED;
+  if (derived2.deps === null) return;
+  for (const dep of derived2.deps) {
+    ((_a5 = dep.reactions) != null ? _a5 : dep.reactions = []).push(derived2);
+    if ((dep.f & DERIVED) !== 0 && (dep.f & CONNECTED) === 0) {
+      unfreeze_derived_effects(
+        /** @type {Derived} */
+        dep
+      );
+      reconnect(
+        /** @type {Derived} */
+        dep
+      );
+    }
+  }
+}
+function depends_on_old_values(derived2) {
+  if (derived2.v === UNINITIALIZED) return true;
+  if (derived2.deps === null) return false;
+  for (const dep of derived2.deps) {
+    if (old_values.has(dep)) {
+      return true;
+    }
+    if ((dep.f & DERIVED) !== 0 && depends_on_old_values(
+      /** @type {Derived} */
+      dep
+    )) {
+      return true;
+    }
+  }
+  return false;
+}
+function untrack(fn) {
+  var previous_untracking = untracking;
+  try {
+    untracking = true;
+    return fn();
+  } finally {
+    untracking = previous_untracking;
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/utils.js
+var DOM_BOOLEAN_ATTRIBUTES = [
+  "allowfullscreen",
+  "async",
+  "autofocus",
+  "autoplay",
+  "checked",
+  "controls",
+  "default",
+  "disabled",
+  "formnovalidate",
+  "indeterminate",
+  "inert",
+  "ismap",
+  "loop",
+  "multiple",
+  "muted",
+  "nomodule",
+  "novalidate",
+  "open",
+  "playsinline",
+  "readonly",
+  "required",
+  "reversed",
+  "seamless",
+  "selected",
+  "webkitdirectory",
+  "defer",
+  "disablepictureinpicture",
+  "disableremoteplayback"
+];
+var DOM_PROPERTIES = [
+  ...DOM_BOOLEAN_ATTRIBUTES,
+  "formNoValidate",
+  "isMap",
+  "noModule",
+  "playsInline",
+  "readOnly",
+  "value",
+  "volume",
+  "defaultValue",
+  "defaultChecked",
+  "srcObject",
+  "noValidate",
+  "allowFullscreen",
+  "disablePictureInPicture",
+  "disableRemotePlayback"
+];
+var PASSIVE_EVENTS = ["touchstart", "touchmove"];
+function is_passive_event(name) {
+  return PASSIVE_EVENTS.includes(name);
+}
+var STATE_CREATION_RUNES = (
+  /** @type {const} */
+  [
+    "$state",
+    "$state.raw",
+    "$derived",
+    "$derived.by"
+  ]
+);
+var RUNES = (
+  /** @type {const} */
+  [
+    ...STATE_CREATION_RUNES,
+    "$state.eager",
+    "$state.snapshot",
+    "$props",
+    "$props.id",
+    "$bindable",
+    "$effect",
+    "$effect.pre",
+    "$effect.tracking",
+    "$effect.root",
+    "$effect.pending",
+    "$inspect",
+    "$inspect().with",
+    "$inspect.trace",
+    "$host"
+  ]
+);
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/elements/events.js
+var event_symbol = Symbol("events");
+var all_registered_events = /* @__PURE__ */ new Set();
+var root_event_handles = /* @__PURE__ */ new Set();
+var last_propagated_event = null;
+function handle_event_propagation(event2) {
+  var _a5, _b3;
+  var handler_element = this;
+  var owner_document = (
+    /** @type {Node} */
+    handler_element.ownerDocument
+  );
+  var event_name = event2.type;
+  var path = ((_a5 = event2.composedPath) == null ? void 0 : _a5.call(event2)) || [];
+  var current_target = (
+    /** @type {null | Element} */
+    path[0] || event2.target
+  );
+  last_propagated_event = event2;
+  var path_idx = 0;
+  var handled_at = last_propagated_event === event2 && event2[event_symbol];
+  if (handled_at) {
+    var at_idx = path.indexOf(handled_at);
+    if (at_idx !== -1 && (handler_element === document || handler_element === /** @type {any} */
+    window)) {
+      event2[event_symbol] = handler_element;
+      return;
+    }
+    var handler_idx = path.indexOf(handler_element);
+    if (handler_idx === -1) {
+      return;
+    }
+    if (at_idx <= handler_idx) {
+      path_idx = at_idx;
+    }
+  }
+  current_target = /** @type {Element} */
+  path[path_idx] || event2.target;
+  if (current_target === handler_element) return;
+  define_property(event2, "currentTarget", {
+    configurable: true,
+    get() {
+      return current_target || owner_document;
+    }
+  });
+  var previous_reaction = active_reaction;
+  var previous_effect = active_effect;
+  set_active_reaction(null);
+  set_active_effect(null);
+  try {
+    var throw_error;
+    var other_errors = [];
+    while (current_target !== null) {
+      var parent_element = current_target.assignedSlot || current_target.parentNode || /** @type {any} */
+      current_target.host || null;
+      try {
+        var delegated2 = (_b3 = current_target[event_symbol]) == null ? void 0 : _b3[event_name];
+        if (delegated2 != null && (!/** @type {any} */
+        current_target.disabled || // DOM could've been updated already by the time this is reached, so we check this as well
+        // -> the target could not have been disabled because it emits the event in the first place
+        event2.target === current_target)) {
+          delegated2.call(current_target, event2);
+        }
+      } catch (error) {
+        if (throw_error) {
+          other_errors.push(error);
+        } else {
+          throw_error = error;
+        }
+      }
+      if (event2.cancelBubble || parent_element === handler_element || parent_element === null) {
+        break;
+      }
+      current_target = parent_element;
+    }
+    if (throw_error) {
+      for (let error of other_errors) {
+        queueMicrotask(() => {
+          throw error;
+        });
+      }
+      throw throw_error;
+    }
+  } finally {
+    event2[event_symbol] = handler_element;
+    delete event2.currentTarget;
+    set_active_reaction(previous_reaction);
+    set_active_effect(previous_effect);
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/reconciler.js
+var _a3;
+var policy = (
+  // We gotta write it like this because after downleveling the pure comment may end up in the wrong location
+  ((_a3 = globalThis == null ? void 0 : globalThis.window) == null ? void 0 : _a3.trustedTypes) && /* @__PURE__ */ globalThis.window.trustedTypes.createPolicy("svelte-trusted-html", {
+    /** @param {string} html */
+    createHTML: (html2) => {
+      return html2;
+    }
+  })
+);
+function create_trusted_html(html2) {
+  var _a5;
+  return (
+    /** @type {string} */
+    (_a5 = policy == null ? void 0 : policy.createHTML(html2)) != null ? _a5 : html2
+  );
+}
+function create_fragment_from_html(html2) {
+  var elem = create_element("template");
+  elem.innerHTML = create_trusted_html(html2.replaceAll("<!>", "<!---->"));
+  return elem.content;
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/template.js
+function assign_nodes(start, end) {
+  var effect2 = (
+    /** @type {Effect} */
+    active_effect
+  );
+  if (effect2.nodes === null) {
+    effect2.nodes = { start, end, a: null, t: null };
+  }
+}
+// @__NO_SIDE_EFFECTS__
+function from_html(content, flags2) {
+  var is_fragment = (flags2 & TEMPLATE_FRAGMENT) !== 0;
+  var use_import_node = (flags2 & TEMPLATE_USE_IMPORT_NODE) !== 0;
+  var node;
+  var has_start = !content.startsWith("<!>");
+  return () => {
+    if (hydrating) {
+      assign_nodes(hydrate_node, null);
+      return hydrate_node;
+    }
+    if (node === void 0) {
+      node = create_fragment_from_html(has_start ? content : "<!>" + content);
+      if (!is_fragment) node = /** @type {TemplateNode} */
+      get_first_child(node);
+    }
+    var clone = (
+      /** @type {TemplateNode} */
+      use_import_node || is_firefox ? document.importNode(node, true) : node.cloneNode(true)
+    );
+    if (is_fragment) {
+      var start = (
+        /** @type {TemplateNode} */
+        get_first_child(clone)
+      );
+      var end = (
+        /** @type {TemplateNode} */
+        clone.lastChild
+      );
+      assign_nodes(start, end);
+    } else {
+      assign_nodes(clone, clone);
+    }
+    return clone;
+  };
+}
+function append(anchor, dom) {
+  if (hydrating) {
+    var effect2 = (
+      /** @type {Effect & { nodes: EffectNodes }} */
+      active_effect
+    );
+    if ((effect2.f & REACTION_RAN) === 0 || effect2.nodes.end === null) {
+      effect2.nodes.end = hydrate_node;
+    }
+    hydrate_next();
+    return;
+  }
+  if (anchor === null) {
+    return;
+  }
+  anchor.before(
+    /** @type {Node} */
+    dom
+  );
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/render.js
+var should_intro = true;
+function set_text(text2, value) {
+  var _a5;
+  var str = value == null ? "" : typeof value === "object" ? `${value}` : value;
+  if (str !== ((_a5 = text2.__t) != null ? _a5 : text2.__t = text2.nodeValue)) {
+    text2.__t = str;
+    text2.nodeValue = `${str}`;
+  }
+}
+function mount(component2, options) {
+  return _mount(component2, options);
+}
+function hydrate(component2, options) {
+  var _a5;
+  init_operations();
+  options.intro = (_a5 = options.intro) != null ? _a5 : false;
+  const target = options.target;
+  const was_hydrating = hydrating;
+  const previous_hydrate_node = hydrate_node;
+  try {
+    var anchor = get_first_child(target);
+    while (anchor && (anchor.nodeType !== COMMENT_NODE || /** @type {Comment} */
+    anchor.data !== HYDRATION_START)) {
+      anchor = get_next_sibling(anchor);
+    }
+    if (!anchor) {
+      throw HYDRATION_ERROR;
+    }
+    set_hydrating(true);
+    set_hydrate_node(
+      /** @type {Comment} */
+      anchor
+    );
+    const instance = _mount(component2, { ...options, anchor });
+    set_hydrating(false);
+    return (
+      /**  @type {Exports} */
+      instance
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.split("\n").some((line) => line.startsWith("https://svelte.dev/e/"))) {
+      throw error;
+    }
+    if (error !== HYDRATION_ERROR) {
+      console.warn("Failed to hydrate: ", error);
+    }
+    if (options.recover === false) {
+      hydration_failed();
+    }
+    init_operations();
+    clear_text_content(target);
+    set_hydrating(false);
+    return mount(component2, options);
+  } finally {
+    set_hydrating(was_hydrating);
+    set_hydrate_node(previous_hydrate_node);
+  }
+}
+var listeners = /* @__PURE__ */ new Map();
+function _mount(Component, { target, anchor, props = {}, events, context, intro = true, transformError }) {
+  init_operations();
+  var component2 = void 0;
+  var unmount2 = component_root(() => {
+    var anchor_node = anchor != null ? anchor : target.appendChild(create_text());
+    boundary(
+      /** @type {TemplateNode} */
+      anchor_node,
+      {
+        pending: () => {
+        }
+      },
+      (anchor_node2) => {
+        push({});
+        var ctx = (
+          /** @type {ComponentContext} */
+          component_context
+        );
+        if (context) ctx.c = context;
+        if (events) {
+          props.$$events = events;
+        }
+        if (hydrating) {
+          assign_nodes(
+            /** @type {TemplateNode} */
+            anchor_node2,
+            null
+          );
+        }
+        should_intro = intro;
+        component2 = Component(anchor_node2, props) || {};
+        should_intro = true;
+        if (hydrating) {
+          active_effect.nodes.end = hydrate_node;
+          if (hydrate_node === null || hydrate_node.nodeType !== COMMENT_NODE || /** @type {Comment} */
+          hydrate_node.data !== HYDRATION_END) {
+            hydration_mismatch();
+            throw HYDRATION_ERROR;
+          }
+        }
+        pop();
+      },
+      transformError
+    );
+    var registered_events = /* @__PURE__ */ new Set();
+    var event_handle = (events2) => {
+      for (var i = 0; i < events2.length; i++) {
+        var event_name = events2[i];
+        if (registered_events.has(event_name)) continue;
+        registered_events.add(event_name);
+        var passive2 = is_passive_event(event_name);
+        for (const node of [target, document]) {
+          var counts = listeners.get(node);
+          if (counts === void 0) {
+            counts = /* @__PURE__ */ new Map();
+            listeners.set(node, counts);
+          }
+          var count = counts.get(event_name);
+          if (count === void 0) {
+            node.addEventListener(event_name, handle_event_propagation, { passive: passive2 });
+            counts.set(event_name, 1);
+          } else {
+            counts.set(event_name, count + 1);
+          }
+        }
+      }
+    };
+    event_handle(array_from(all_registered_events));
+    root_event_handles.add(event_handle);
+    return () => {
+      var _a5;
+      for (var event_name of registered_events) {
+        for (const node of [target, document]) {
+          var counts = (
+            /** @type {Map<string, number>} */
+            listeners.get(node)
+          );
+          var count = (
+            /** @type {number} */
+            counts.get(event_name)
+          );
+          if (--count == 0) {
+            node.removeEventListener(event_name, handle_event_propagation);
+            counts.delete(event_name);
+            if (counts.size === 0) {
+              listeners.delete(node);
+            }
+          } else {
+            counts.set(event_name, count);
+          }
+        }
+      }
+      root_event_handles.delete(event_handle);
+      if (anchor_node !== anchor) {
+        (_a5 = anchor_node.parentNode) == null ? void 0 : _a5.removeChild(anchor_node);
+      }
+    };
+  });
+  mounted_components.set(component2, unmount2);
+  return component2;
+}
+var mounted_components = /* @__PURE__ */ new WeakMap();
+function unmount(component2, options) {
+  const fn = mounted_components.get(component2);
+  if (fn) {
+    mounted_components.delete(component2);
+    return fn(options);
+  }
+  if (dev_fallback_default) {
+    if (STATE_SYMBOL in component2) {
+      state_proxy_unmount();
+    } else {
+      lifecycle_double_unmount();
+    }
+  }
+  return Promise.resolve();
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/blocks/branches.js
+var _batches, _onscreen, _offscreen, _outroing, _transition, _commit, _discard;
+var BranchManager = class {
+  /**
+   * @param {TemplateNode} anchor
+   * @param {boolean} transition
+   */
+  constructor(anchor, transition2 = true) {
+    /** @type {TemplateNode} */
+    __publicField(this, "anchor");
+    /** @type {Map<Batch, Key>} */
+    __privateAdd(this, _batches, /* @__PURE__ */ new Map());
+    /**
+     * Map of keys to effects that are currently rendered in the DOM.
+     * These effects are visible and actively part of the document tree.
+     * Example:
+     * ```
+     * {#if condition}
+     * 	foo
+     * {:else}
+     * 	bar
+     * {/if}
+     * ```
+     * Can result in the entries `true->Effect` and `false->Effect`
+     * @type {Map<Key, Effect>}
+     */
+    __privateAdd(this, _onscreen, /* @__PURE__ */ new Map());
+    /**
+     * Similar to #onscreen with respect to the keys, but contains branches that are not yet
+     * in the DOM, because their insertion is deferred.
+     * @type {Map<Key, Branch>}
+     */
+    __privateAdd(this, _offscreen, /* @__PURE__ */ new Map());
+    /**
+     * Keys of effects that are currently outroing
+     * @type {Set<Key>}
+     */
+    __privateAdd(this, _outroing, /* @__PURE__ */ new Set());
+    /**
+     * Whether to pause (i.e. outro) on change, or destroy immediately.
+     * This is necessary for `<svelte:element>`
+     */
+    __privateAdd(this, _transition, true);
+    /**
+     * @param {Batch} batch
+     */
+    __privateAdd(this, _commit, (batch) => {
+      if (!__privateGet(this, _batches).has(batch)) return;
+      var key2 = (
+        /** @type {Key} */
+        __privateGet(this, _batches).get(batch)
+      );
+      var onscreen = __privateGet(this, _onscreen).get(key2);
+      if (onscreen) {
+        resume_effect(onscreen);
+        __privateGet(this, _outroing).delete(key2);
+      } else {
+        var offscreen = __privateGet(this, _offscreen).get(key2);
+        if (offscreen) {
+          __privateGet(this, _onscreen).set(key2, offscreen.effect);
+          __privateGet(this, _offscreen).delete(key2);
+          if (dev_fallback_default) {
+            offscreen.fragment.lastChild[HMR_ANCHOR] = this.anchor;
+          }
+          offscreen.fragment.lastChild.remove();
+          this.anchor.before(offscreen.fragment);
+          onscreen = offscreen.effect;
+        }
+      }
+      for (const [b, k] of __privateGet(this, _batches)) {
+        __privateGet(this, _batches).delete(b);
+        if (b === batch) {
+          break;
+        }
+        const offscreen2 = __privateGet(this, _offscreen).get(k);
+        if (offscreen2) {
+          destroy_effect(offscreen2.effect);
+          __privateGet(this, _offscreen).delete(k);
+        }
+      }
+      for (const [k, effect2] of __privateGet(this, _onscreen)) {
+        if (k === key2 || __privateGet(this, _outroing).has(k)) continue;
+        const on_destroy = () => {
+          const keys = Array.from(__privateGet(this, _batches).values());
+          if (keys.includes(k)) {
+            var fragment = document.createDocumentFragment();
+            move_effect(effect2, fragment);
+            fragment.append(create_text());
+            __privateGet(this, _offscreen).set(k, { effect: effect2, fragment });
+          } else {
+            destroy_effect(effect2);
+          }
+          __privateGet(this, _outroing).delete(k);
+          __privateGet(this, _onscreen).delete(k);
+        };
+        if (__privateGet(this, _transition) || !onscreen) {
+          __privateGet(this, _outroing).add(k);
+          pause_effect(effect2, on_destroy, false);
+        } else {
+          on_destroy();
+        }
+      }
+    });
+    /**
+     * @param {Batch} batch
+     */
+    __privateAdd(this, _discard, (batch) => {
+      __privateGet(this, _batches).delete(batch);
+      const keys = Array.from(__privateGet(this, _batches).values());
+      for (const [k, branch2] of __privateGet(this, _offscreen)) {
+        if (!keys.includes(k)) {
+          destroy_effect(branch2.effect);
+          __privateGet(this, _offscreen).delete(k);
+        }
+      }
+    });
+    this.anchor = anchor;
+    __privateSet(this, _transition, transition2);
+  }
+  /**
+   *
+   * @param {any} key
+   * @param {null | ((target: TemplateNode) => void)} fn
+   */
+  ensure(key2, fn) {
+    var batch = (
+      /** @type {Batch} */
+      current_batch
+    );
+    var defer = should_defer_append();
+    if (fn && !__privateGet(this, _onscreen).has(key2) && !__privateGet(this, _offscreen).has(key2)) {
+      if (defer) {
+        var fragment = document.createDocumentFragment();
+        var target = create_text();
+        fragment.append(target);
+        __privateGet(this, _offscreen).set(key2, {
+          effect: branch(() => fn(target)),
+          fragment
+        });
+      } else {
+        __privateGet(this, _onscreen).set(
+          key2,
+          branch(() => fn(this.anchor))
+        );
+      }
+    }
+    __privateGet(this, _batches).set(batch, key2);
+    if (defer) {
+      for (const [k, effect2] of __privateGet(this, _onscreen)) {
+        if (k === key2) {
+          batch.unskip_effect(effect2);
+        } else {
+          batch.skip_effect(effect2);
+        }
+      }
+      for (const [k, branch2] of __privateGet(this, _offscreen)) {
+        if (k === key2) {
+          batch.unskip_effect(branch2.effect);
+        } else {
+          batch.skip_effect(branch2.effect);
+        }
+      }
+      batch.oncommit(__privateGet(this, _commit));
+      batch.ondiscard(__privateGet(this, _discard));
+    } else {
+      if (hydrating) {
+        this.anchor = hydrate_node;
+      }
+      __privateGet(this, _commit).call(this, batch);
+    }
+  }
+};
+_batches = new WeakMap();
+_onscreen = new WeakMap();
+_offscreen = new WeakMap();
+_outroing = new WeakMap();
+_transition = new WeakMap();
+_commit = new WeakMap();
+_discard = new WeakMap();
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/blocks/if.js
+function if_block(node, fn, elseif = false) {
+  var marker;
+  if (hydrating) {
+    marker = hydrate_node;
+    hydrate_next();
+  }
+  var branches = new BranchManager(node);
+  var flags2 = elseif ? EFFECT_TRANSPARENT : 0;
+  function update_branch(key2, fn2) {
+    if (hydrating) {
+      var data = read_hydration_instruction(
+        /** @type {TemplateNode} */
+        marker
+      );
+      if (key2 !== parseInt(data.substring(1))) {
+        var anchor = skip_nodes();
+        set_hydrate_node(anchor);
+        branches.anchor = anchor;
+        set_hydrating(false);
+        branches.ensure(key2, fn2);
+        set_hydrating(true);
+        return;
+      }
+    }
+    branches.ensure(key2, fn2);
+  }
+  block(() => {
+    var has_branch = false;
+    fn((fn2, key2 = 0) => {
+      has_branch = true;
+      update_branch(key2, fn2);
+    });
+    if (!has_branch) {
+      update_branch(-1, null);
+    }
+  }, flags2);
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/blocks/key.js
+var NAN = Symbol("NaN");
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/blocks/each.js
+function pause_effects(state2, to_destroy, controlled_anchor) {
+  var _a5;
+  var transitions = [];
+  var length = to_destroy.length;
+  var group;
+  var remaining = to_destroy.length;
+  for (var i = 0; i < length; i++) {
+    let effect2 = to_destroy[i];
+    pause_effect(
+      effect2,
+      () => {
+        if (group) {
+          group.pending.delete(effect2);
+          group.done.add(effect2);
+          if (group.pending.size === 0) {
+            var groups = (
+              /** @type {Set<EachOutroGroup>} */
+              state2.outrogroups
+            );
+            destroy_effects(state2, array_from(group.done));
+            groups.delete(group);
+            if (groups.size === 0) {
+              state2.outrogroups = null;
+            }
+          }
+        } else {
+          remaining -= 1;
+        }
+      },
+      false
+    );
+  }
+  if (remaining === 0) {
+    var fast_path = transitions.length === 0 && controlled_anchor !== null;
+    if (fast_path) {
+      var anchor = (
+        /** @type {Element} */
+        controlled_anchor
+      );
+      var parent_node = (
+        /** @type {Element} */
+        anchor.parentNode
+      );
+      clear_text_content(parent_node);
+      parent_node.append(anchor);
+      state2.items.clear();
+    }
+    destroy_effects(state2, to_destroy, !fast_path);
+  } else {
+    group = {
+      pending: new Set(to_destroy),
+      done: /* @__PURE__ */ new Set()
+    };
+    ((_a5 = state2.outrogroups) != null ? _a5 : state2.outrogroups = /* @__PURE__ */ new Set()).add(group);
+  }
+}
+function destroy_effects(state2, to_destroy, remove_dom = true) {
+  var preserved_effects;
+  if (state2.pending.size > 0) {
+    preserved_effects = /* @__PURE__ */ new Set();
+    for (const keys of state2.pending.values()) {
+      for (const key2 of keys) {
+        preserved_effects.add(
+          /** @type {EachItem} */
+          state2.items.get(key2).e
+        );
+      }
+    }
+  }
+  for (var i = 0; i < to_destroy.length; i++) {
+    var e = to_destroy[i];
+    if (preserved_effects == null ? void 0 : preserved_effects.has(e)) {
+      e.f |= EFFECT_OFFSCREEN;
+      const fragment = document.createDocumentFragment();
+      move_effect(e, fragment);
+    } else {
+      destroy_effect(to_destroy[i], remove_dom);
+    }
+  }
+}
+var offscreen_anchor;
+function each(node, flags2, get_collection, get_key, render_fn2, fallback_fn = null) {
+  var anchor = node;
+  var items = /* @__PURE__ */ new Map();
+  var is_controlled = (flags2 & EACH_IS_CONTROLLED) !== 0;
+  if (is_controlled) {
+    var parent_node = (
+      /** @type {Element} */
+      node
+    );
+    anchor = hydrating ? set_hydrate_node(get_first_child(parent_node)) : parent_node.appendChild(create_text());
+  }
+  if (hydrating) {
+    hydrate_next();
+  }
+  var fallback2 = null;
+  var each_array = derived_safe_equal(() => {
+    var collection = get_collection();
+    return is_array(collection) ? collection : collection == null ? [] : array_from(collection);
+  });
+  if (dev_fallback_default) {
+    tag(each_array, "{#each ...}");
+  }
+  var array;
+  var pending2 = /* @__PURE__ */ new Map();
+  var first_run = true;
+  function commit(batch) {
+    if ((state2.effect.f & DESTROYED) !== 0) {
+      return;
+    }
+    state2.pending.delete(batch);
+    state2.fallback = fallback2;
+    reconcile(state2, array, anchor, flags2, get_key);
+    if (fallback2 !== null) {
+      if (array.length === 0) {
+        if ((fallback2.f & EFFECT_OFFSCREEN) === 0) {
+          resume_effect(fallback2);
+        } else {
+          fallback2.f ^= EFFECT_OFFSCREEN;
+          move(fallback2, null, anchor);
+        }
+      } else {
+        pause_effect(fallback2, () => {
+          fallback2 = null;
+        });
+      }
+    }
+  }
+  function discard(batch) {
+    state2.pending.delete(batch);
+  }
+  var effect2 = block(() => {
+    array = /** @type {V[]} */
+    get2(each_array);
+    var length = array.length;
+    let mismatch = false;
+    if (hydrating) {
+      var is_else = read_hydration_instruction(anchor) === HYDRATION_START_ELSE;
+      if (is_else !== (length === 0)) {
+        anchor = skip_nodes();
+        set_hydrate_node(anchor);
+        set_hydrating(false);
+        mismatch = true;
+      }
+    }
+    var keys = /* @__PURE__ */ new Set();
+    var batch = (
+      /** @type {Batch} */
+      current_batch
+    );
+    var defer = should_defer_append();
+    for (var index2 = 0; index2 < length; index2 += 1) {
+      if (hydrating && hydrate_node.nodeType === COMMENT_NODE && /** @type {Comment} */
+      hydrate_node.data === HYDRATION_END) {
+        anchor = /** @type {Comment} */
+        hydrate_node;
+        mismatch = true;
+        set_hydrating(false);
+      }
+      var value = array[index2];
+      var key2 = get_key(value, index2);
+      if (dev_fallback_default) {
+        var key_again = get_key(value, index2);
+        if (key2 !== key_again) {
+          each_key_volatile(String(index2), String(key2), String(key_again));
+        }
+      }
+      var item = first_run ? null : items.get(key2);
+      if (item) {
+        if (item.v) internal_set(item.v, value);
+        if (item.i) internal_set(item.i, index2);
+        if (defer) {
+          batch.unskip_effect(item.e);
+        }
+      } else {
+        item = create_item(
+          items,
+          first_run ? anchor : offscreen_anchor != null ? offscreen_anchor : offscreen_anchor = create_text(),
+          value,
+          key2,
+          index2,
+          render_fn2,
+          flags2,
+          get_collection
+        );
+        if (!first_run) {
+          item.e.f |= EFFECT_OFFSCREEN;
+        }
+        items.set(key2, item);
+      }
+      keys.add(key2);
+    }
+    if (length === 0 && fallback_fn && !fallback2) {
+      if (first_run) {
+        fallback2 = branch(() => fallback_fn(anchor));
+      } else {
+        fallback2 = branch(() => fallback_fn(offscreen_anchor != null ? offscreen_anchor : offscreen_anchor = create_text()));
+        fallback2.f |= EFFECT_OFFSCREEN;
+      }
+    }
+    if (length > keys.size) {
+      if (dev_fallback_default) {
+        validate_each_keys(array, get_key);
+      } else {
+        each_key_duplicate("", "", "");
+      }
+    }
+    if (hydrating && length > 0) {
+      set_hydrate_node(skip_nodes());
+    }
+    if (!first_run) {
+      pending2.set(batch, keys);
+      if (defer) {
+        for (const [key3, item2] of items) {
+          if (!keys.has(key3)) {
+            batch.skip_effect(item2.e);
+          }
+        }
+        batch.oncommit(commit);
+        batch.ondiscard(discard);
+      } else {
+        commit(batch);
+      }
+    }
+    if (mismatch) {
+      set_hydrating(true);
+    }
+    get2(each_array);
+  });
+  var state2 = { effect: effect2, flags: flags2, items, pending: pending2, outrogroups: null, fallback: fallback2 };
+  first_run = false;
+  if (hydrating) {
+    anchor = hydrate_node;
+  }
+}
+function skip_to_branch(effect2) {
+  while (effect2 !== null && (effect2.f & BRANCH_EFFECT) === 0) {
+    effect2 = effect2.next;
+  }
+  return effect2;
+}
+function reconcile(state2, array, anchor, flags2, get_key) {
+  var _a5, _b3, _c2, _d, _e, _f, _g, _h, _i;
+  var is_animated = (flags2 & EACH_IS_ANIMATED) !== 0;
+  var length = array.length;
+  var items = state2.items;
+  var current = skip_to_branch(state2.effect.first);
+  var seen;
+  var prev = null;
+  var to_animate;
+  var matched = [];
+  var stashed = [];
+  var value;
+  var key2;
+  var effect2;
+  var i;
+  if (is_animated) {
+    for (i = 0; i < length; i += 1) {
+      value = array[i];
+      key2 = get_key(value, i);
+      effect2 = /** @type {EachItem} */
+      items.get(key2).e;
+      if ((effect2.f & EFFECT_OFFSCREEN) === 0) {
+        (_b3 = (_a5 = effect2.nodes) == null ? void 0 : _a5.a) == null ? void 0 : _b3.measure();
+        (to_animate != null ? to_animate : to_animate = /* @__PURE__ */ new Set()).add(effect2);
+      }
+    }
+  }
+  for (i = 0; i < length; i += 1) {
+    value = array[i];
+    key2 = get_key(value, i);
+    effect2 = /** @type {EachItem} */
+    items.get(key2).e;
+    if (state2.outrogroups !== null) {
+      for (const group of state2.outrogroups) {
+        group.pending.delete(effect2);
+        group.done.delete(effect2);
+      }
+    }
+    if ((effect2.f & INERT) !== 0) {
+      resume_effect(effect2);
+      if (is_animated) {
+        (_d = (_c2 = effect2.nodes) == null ? void 0 : _c2.a) == null ? void 0 : _d.unfix();
+        (to_animate != null ? to_animate : to_animate = /* @__PURE__ */ new Set()).delete(effect2);
+      }
+    }
+    if ((effect2.f & EFFECT_OFFSCREEN) !== 0) {
+      effect2.f ^= EFFECT_OFFSCREEN;
+      if (effect2 === current) {
+        move(effect2, null, anchor);
+      } else {
+        var next2 = prev ? prev.next : current;
+        if (effect2 === state2.effect.last) {
+          state2.effect.last = effect2.prev;
+        }
+        if (effect2.prev) effect2.prev.next = effect2.next;
+        if (effect2.next) effect2.next.prev = effect2.prev;
+        link(state2, prev, effect2);
+        link(state2, effect2, next2);
+        move(effect2, next2, anchor);
+        prev = effect2;
+        matched = [];
+        stashed = [];
+        current = skip_to_branch(prev.next);
+        continue;
+      }
+    }
+    if (effect2 !== current) {
+      if (seen !== void 0 && seen.has(effect2)) {
+        if (matched.length < stashed.length) {
+          var start = stashed[0];
+          var j;
+          prev = start.prev;
+          var a = matched[0];
+          var b = matched[matched.length - 1];
+          for (j = 0; j < matched.length; j += 1) {
+            move(matched[j], start, anchor);
+          }
+          for (j = 0; j < stashed.length; j += 1) {
+            seen.delete(stashed[j]);
+          }
+          link(state2, a.prev, b.next);
+          link(state2, prev, a);
+          link(state2, b, start);
+          current = start;
+          prev = b;
+          i -= 1;
+          matched = [];
+          stashed = [];
+        } else {
+          seen.delete(effect2);
+          move(effect2, current, anchor);
+          link(state2, effect2.prev, effect2.next);
+          link(state2, effect2, prev === null ? state2.effect.first : prev.next);
+          link(state2, prev, effect2);
+          prev = effect2;
+        }
+        continue;
+      }
+      matched = [];
+      stashed = [];
+      while (current !== null && current !== effect2) {
+        (seen != null ? seen : seen = /* @__PURE__ */ new Set()).add(current);
+        stashed.push(current);
+        current = skip_to_branch(current.next);
+      }
+      if (current === null) {
+        continue;
+      }
+    }
+    if ((effect2.f & EFFECT_OFFSCREEN) === 0) {
+      matched.push(effect2);
+    }
+    prev = effect2;
+    current = skip_to_branch(effect2.next);
+  }
+  if (state2.outrogroups !== null) {
+    for (const group of state2.outrogroups) {
+      if (group.pending.size === 0) {
+        destroy_effects(state2, array_from(group.done));
+        (_e = state2.outrogroups) == null ? void 0 : _e.delete(group);
+      }
+    }
+    if (state2.outrogroups.size === 0) {
+      state2.outrogroups = null;
+    }
+  }
+  if (current !== null || seen !== void 0) {
+    var to_destroy = [];
+    if (seen !== void 0) {
+      for (effect2 of seen) {
+        if ((effect2.f & INERT) === 0) {
+          to_destroy.push(effect2);
+        }
+      }
+    }
+    while (current !== null) {
+      if ((current.f & INERT) === 0 && current !== state2.fallback) {
+        to_destroy.push(current);
+      }
+      current = skip_to_branch(current.next);
+    }
+    var destroy_length = to_destroy.length;
+    if (destroy_length > 0) {
+      var controlled_anchor = (flags2 & EACH_IS_CONTROLLED) !== 0 && length === 0 ? anchor : null;
+      if (is_animated) {
+        for (i = 0; i < destroy_length; i += 1) {
+          (_g = (_f = to_destroy[i].nodes) == null ? void 0 : _f.a) == null ? void 0 : _g.measure();
+        }
+        for (i = 0; i < destroy_length; i += 1) {
+          (_i = (_h = to_destroy[i].nodes) == null ? void 0 : _h.a) == null ? void 0 : _i.fix();
+        }
+      }
+      pause_effects(state2, to_destroy, controlled_anchor);
+    }
+  }
+  if (is_animated) {
+    queue_micro_task(() => {
+      var _a6, _b4;
+      if (to_animate === void 0) return;
+      for (effect2 of to_animate) {
+        (_b4 = (_a6 = effect2.nodes) == null ? void 0 : _a6.a) == null ? void 0 : _b4.apply();
+      }
+    });
+  }
+}
+function create_item(items, anchor, value, key2, index2, render_fn2, flags2, get_collection) {
+  var v = (flags2 & EACH_ITEM_REACTIVE) !== 0 ? (flags2 & EACH_ITEM_IMMUTABLE) === 0 ? mutable_source(value, false, false) : source(value) : null;
+  var i = (flags2 & EACH_INDEX_REACTIVE) !== 0 ? source(index2) : null;
+  if (dev_fallback_default && v) {
+    v.trace = () => {
+      var _a5;
+      get_collection()[(_a5 = i == null ? void 0 : i.v) != null ? _a5 : index2];
+    };
+  }
+  return {
+    v,
+    i,
+    e: branch(() => {
+      render_fn2(anchor, v != null ? v : value, i != null ? i : index2, get_collection);
+      return () => {
+        items.delete(key2);
+      };
+    })
+  };
+}
+function move(effect2, next2, anchor) {
+  if (!effect2.nodes) return;
+  var node = effect2.nodes.start;
+  var end = effect2.nodes.end;
+  var dest = next2 && (next2.f & EFFECT_OFFSCREEN) === 0 ? (
+    /** @type {EffectNodes} */
+    next2.nodes.start
+  ) : anchor;
+  while (node !== null) {
+    var next_node = (
+      /** @type {TemplateNode} */
+      get_next_sibling(node)
+    );
+    dest.before(node);
+    if (node === end) {
+      return;
+    }
+    node = next_node;
+  }
+}
+function link(state2, prev, next2) {
+  if (prev === null) {
+    state2.effect.first = next2;
+  } else {
+    prev.next = next2;
+  }
+  if (next2 === null) {
+    state2.effect.last = prev;
+  } else {
+    next2.prev = prev;
+  }
+}
+function validate_each_keys(array, key_fn) {
+  const keys = /* @__PURE__ */ new Map();
+  const length = array.length;
+  for (let i = 0; i < length; i++) {
+    const key2 = key_fn(array[i], i);
+    if (keys.has(key2)) {
+      const a = String(keys.get(key2));
+      const b = String(i);
+      let k = String(key2);
+      if (k.startsWith("[object ")) k = null;
+      each_key_duplicate(a, b, k);
+    }
+    keys.set(key2, i);
+  }
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/shared/attributes.js
+var whitespace = [..." 	\n\r\f\xA0\v\uFEFF"];
+function to_class(value, hash2, directives) {
+  var classname = value == null ? "" : "" + value;
+  if (hash2) {
+    classname = classname ? classname + " " + hash2 : hash2;
+  }
+  if (directives) {
+    for (var key2 of Object.keys(directives)) {
+      if (directives[key2]) {
+        classname = classname ? classname + " " + key2 : key2;
+      } else if (classname.length) {
+        var len = key2.length;
+        var a = 0;
+        while ((a = classname.indexOf(key2, a)) >= 0) {
+          var b = a + len;
+          if ((a === 0 || whitespace.includes(classname[a - 1])) && (b === classname.length || whitespace.includes(classname[b]))) {
+            classname = (a === 0 ? "" : classname.substring(0, a)) + classname.substring(b + 1);
+          } else {
+            a = b;
+          }
+        }
+      }
+    }
+  }
+  return classname === "" ? null : classname;
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/elements/class.js
+function set_class(dom, is_html, value, hash2, prev_classes, next_classes) {
+  var prev = dom.__className;
+  if (hydrating || prev !== value || prev === void 0) {
+    var next_class_name = to_class(value, hash2, next_classes);
+    if (!hydrating || next_class_name !== dom.getAttribute("class")) {
+      if (next_class_name == null) {
+        dom.removeAttribute("class");
+      } else if (is_html) {
+        dom.className = next_class_name;
+      } else {
+        dom.setAttribute("class", next_class_name);
+      }
+    }
+    dom.__className = value;
+  } else if (next_classes && prev_classes !== next_classes) {
+    for (var key2 in next_classes) {
+      var is_present = !!next_classes[key2];
+      if (prev_classes == null || is_present !== !!prev_classes[key2]) {
+        dom.classList.toggle(key2, is_present);
+      }
+    }
+  }
+  return next_classes;
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/elements/attributes.js
+var CLASS = Symbol("class");
+var STYLE = Symbol("style");
+var IS_CUSTOM_ELEMENT = Symbol("is custom element");
+var IS_HTML = Symbol("is html");
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/legacy/legacy-client.js
+function createClassComponent(options) {
+  return new Svelte4Component(options);
+}
+var _events, _instance;
+var Svelte4Component = class {
+  /**
+   * @param {ComponentConstructorOptions & {
+   *  component: any;
+   * }} options
+   */
+  constructor(options) {
+    /** @type {any} */
+    __privateAdd(this, _events);
+    /** @type {Record<string, any>} */
+    __privateAdd(this, _instance);
+    var _a5, _b3;
+    var sources = /* @__PURE__ */ new Map();
+    var add_source = (key2, value) => {
+      var s = mutable_source(value, false, false);
+      sources.set(key2, s);
+      return s;
+    };
+    const props = new Proxy(
+      { ...options.props || {}, $$events: {} },
+      {
+        get(target, prop2) {
+          var _a6;
+          return get2((_a6 = sources.get(prop2)) != null ? _a6 : add_source(prop2, Reflect.get(target, prop2)));
+        },
+        has(target, prop2) {
+          var _a6;
+          if (prop2 === LEGACY_PROPS) return true;
+          get2((_a6 = sources.get(prop2)) != null ? _a6 : add_source(prop2, Reflect.get(target, prop2)));
+          return Reflect.has(target, prop2);
+        },
+        set(target, prop2, value) {
+          var _a6;
+          set((_a6 = sources.get(prop2)) != null ? _a6 : add_source(prop2, value), value);
+          return Reflect.set(target, prop2, value);
+        }
+      }
+    );
+    __privateSet(this, _instance, (options.hydrate ? hydrate : mount)(options.component, {
+      target: options.target,
+      anchor: options.anchor,
+      props,
+      context: options.context,
+      intro: (_a5 = options.intro) != null ? _a5 : false,
+      recover: options.recover,
+      transformError: options.transformError
+    }));
+    if (!async_mode_flag && (!((_b3 = options == null ? void 0 : options.props) == null ? void 0 : _b3.$$host) || options.sync === false)) {
+      flushSync();
+    }
+    __privateSet(this, _events, props.$$events);
+    for (const key2 of Object.keys(__privateGet(this, _instance))) {
+      if (key2 === "$set" || key2 === "$destroy" || key2 === "$on") continue;
+      define_property(this, key2, {
+        get() {
+          return __privateGet(this, _instance)[key2];
+        },
+        /** @param {any} value */
+        set(value) {
+          __privateGet(this, _instance)[key2] = value;
+        },
+        enumerable: true
+      });
+    }
+    __privateGet(this, _instance).$set = /** @param {Record<string, any>} next */
+    (next2) => {
+      Object.assign(props, next2);
+    };
+    __privateGet(this, _instance).$destroy = () => {
+      unmount(__privateGet(this, _instance));
+    };
+  }
+  /** @param {Record<string, any>} props */
+  $set(props) {
+    __privateGet(this, _instance).$set(props);
+  }
+  /**
+   * @param {string} event
+   * @param {(...args: any[]) => any} callback
+   * @returns {any}
+   */
+  $on(event2, callback) {
+    __privateGet(this, _events)[event2] = __privateGet(this, _events)[event2] || [];
+    const cb = (...args) => callback.call(this, ...args);
+    __privateGet(this, _events)[event2].push(cb);
+    return () => {
+      __privateGet(this, _events)[event2] = __privateGet(this, _events)[event2].filter(
+        /** @param {any} fn */
+        (fn) => fn !== cb
+      );
+    };
+  }
+  $destroy() {
+    __privateGet(this, _instance).$destroy();
+  }
+};
+_events = new WeakMap();
+_instance = new WeakMap();
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/client/dom/elements/custom-element.js
+var SvelteElement;
+if (typeof HTMLElement === "function") {
+  SvelteElement = class extends HTMLElement {
+    /**
+     * @param {*} $$componentCtor
+     * @param {*} $$slots
+     * @param {ShadowRootInit | undefined} shadow_root_init
+     */
+    constructor($$componentCtor, $$slots, shadow_root_init) {
+      super();
+      /** The Svelte component constructor */
+      __publicField(this, "$$ctor");
+      /** Slots */
+      __publicField(this, "$$s");
+      /** @type {any} The Svelte component instance */
+      __publicField(this, "$$c");
+      /** Whether or not the custom element is connected */
+      __publicField(this, "$$cn", false);
+      /** @type {Record<string, any>} Component props data */
+      __publicField(this, "$$d", {});
+      /** `true` if currently in the process of reflecting component props back to attributes */
+      __publicField(this, "$$r", false);
+      /** @type {Record<string, CustomElementPropDefinition>} Props definition (name, reflected, type etc) */
+      __publicField(this, "$$p_d", {});
+      /** @type {Record<string, EventListenerOrEventListenerObject[]>} Event listeners */
+      __publicField(this, "$$l", {});
+      /** @type {Map<EventListenerOrEventListenerObject, Function>} Event listener unsubscribe functions */
+      __publicField(this, "$$l_u", /* @__PURE__ */ new Map());
+      /** @type {any} The managed render effect for reflecting attributes */
+      __publicField(this, "$$me");
+      /** @type {ShadowRoot | null} The ShadowRoot of the custom element */
+      __publicField(this, "$$shadowRoot", null);
+      this.$$ctor = $$componentCtor;
+      this.$$s = $$slots;
+      if (shadow_root_init) {
+        this.$$shadowRoot = this.attachShadow(shadow_root_init);
+      }
+    }
+    /**
+     * @param {string} type
+     * @param {EventListenerOrEventListenerObject} listener
+     * @param {boolean | AddEventListenerOptions} [options]
+     */
+    addEventListener(type, listener, options) {
+      this.$$l[type] = this.$$l[type] || [];
+      this.$$l[type].push(listener);
+      if (this.$$c) {
+        const unsub = this.$$c.$on(type, listener);
+        this.$$l_u.set(listener, unsub);
+      }
+      super.addEventListener(type, listener, options);
+    }
+    /**
+     * @param {string} type
+     * @param {EventListenerOrEventListenerObject} listener
+     * @param {boolean | AddEventListenerOptions} [options]
+     */
+    removeEventListener(type, listener, options) {
+      super.removeEventListener(type, listener, options);
+      if (this.$$c) {
+        const unsub = this.$$l_u.get(listener);
+        if (unsub) {
+          unsub();
+          this.$$l_u.delete(listener);
+        }
+      }
+    }
+    async connectedCallback() {
+      this.$$cn = true;
+      if (!this.$$c) {
+        let create_slot = function(name) {
+          return (anchor) => {
+            const slot2 = create_element("slot");
+            if (name !== "default") slot2.name = name;
+            append(anchor, slot2);
+          };
+        };
+        await Promise.resolve();
+        if (!this.$$cn || this.$$c) {
+          return;
+        }
+        const $$slots = {};
+        const existing_slots = get_custom_elements_slots(this);
+        for (const name of this.$$s) {
+          if (name in existing_slots) {
+            if (name === "default" && !this.$$d.children) {
+              this.$$d.children = create_slot(name);
+              $$slots.default = true;
+            } else {
+              $$slots[name] = create_slot(name);
+            }
+          }
+        }
+        for (const attribute of this.attributes) {
+          const name = this.$$g_p(attribute.name);
+          if (!(name in this.$$d)) {
+            this.$$d[name] = get_custom_element_value(name, attribute.value, this.$$p_d, "toProp");
+          }
+        }
+        for (const key2 in this.$$p_d) {
+          if (!(key2 in this.$$d) && this[key2] !== void 0) {
+            this.$$d[key2] = this[key2];
+            delete this[key2];
+          }
+        }
+        this.$$c = createClassComponent({
+          component: this.$$ctor,
+          target: this.$$shadowRoot || this,
+          props: {
+            ...this.$$d,
+            $$slots,
+            $$host: this
+          }
+        });
+        this.$$me = effect_root(() => {
+          render_effect(() => {
+            var _a5;
+            this.$$r = true;
+            for (const key2 of object_keys(this.$$c)) {
+              if (!((_a5 = this.$$p_d[key2]) == null ? void 0 : _a5.reflect)) continue;
+              this.$$d[key2] = this.$$c[key2];
+              const attribute_value = get_custom_element_value(
+                key2,
+                this.$$d[key2],
+                this.$$p_d,
+                "toAttribute"
+              );
+              if (attribute_value == null) {
+                this.removeAttribute(this.$$p_d[key2].attribute || key2);
+              } else {
+                this.setAttribute(this.$$p_d[key2].attribute || key2, attribute_value);
+              }
+            }
+            this.$$r = false;
+          });
+        });
+        for (const type in this.$$l) {
+          for (const listener of this.$$l[type]) {
+            const unsub = this.$$c.$on(type, listener);
+            this.$$l_u.set(listener, unsub);
+          }
+        }
+        this.$$l = {};
+      }
+    }
+    // We don't need this when working within Svelte code, but for compatibility of people using this outside of Svelte
+    // and setting attributes through setAttribute etc, this is helpful
+    /**
+     * @param {string} attr
+     * @param {string} _oldValue
+     * @param {string} newValue
+     */
+    attributeChangedCallback(attr2, _oldValue, newValue) {
+      var _a5;
+      if (this.$$r) return;
+      attr2 = this.$$g_p(attr2);
+      this.$$d[attr2] = get_custom_element_value(attr2, newValue, this.$$p_d, "toProp");
+      (_a5 = this.$$c) == null ? void 0 : _a5.$set({ [attr2]: this.$$d[attr2] });
+    }
+    disconnectedCallback() {
+      this.$$cn = false;
+      Promise.resolve().then(() => {
+        if (!this.$$cn && this.$$c) {
+          this.$$c.$destroy();
+          this.$$me();
+          this.$$c = void 0;
+        }
+      });
+    }
+    /**
+     * @param {string} attribute_name
+     */
+    $$g_p(attribute_name) {
+      return object_keys(this.$$p_d).find(
+        (key2) => this.$$p_d[key2].attribute === attribute_name || !this.$$p_d[key2].attribute && key2.toLowerCase() === attribute_name
+      ) || attribute_name;
+    }
+  };
+}
+function get_custom_element_value(prop2, value, props_definition, transform) {
+  var _a5;
+  const type = (_a5 = props_definition[prop2]) == null ? void 0 : _a5.type;
+  value = type === "Boolean" && typeof value !== "boolean" ? value != null : value;
+  if (!transform || !props_definition[prop2]) {
+    return value;
+  } else if (transform === "toAttribute") {
+    switch (type) {
+      case "Object":
+      case "Array":
+        return value == null ? null : JSON.stringify(value);
+      case "Boolean":
+        return value ? "" : null;
+      case "Number":
+        return value == null ? null : value;
+      default:
+        return value;
+    }
+  } else {
+    switch (type) {
+      case "Object":
+      case "Array":
+        return value && JSON.parse(value);
+      case "Boolean":
+        return value;
+      case "Number":
+        return value != null ? +value : value;
+      default:
+        return value;
+    }
+  }
+}
+function get_custom_elements_slots(element2) {
+  const result = {};
+  element2.childNodes.forEach((node) => {
+    result[
+      /** @type {Element} node */
+      node.slot || "default"
+    ] = true;
+  });
+  return result;
+}
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/index-client.js
+if (dev_fallback_default) {
+  let throw_rune_error = function(rune) {
+    if (!(rune in globalThis)) {
+      let value;
+      Object.defineProperty(globalThis, rune, {
+        configurable: true,
+        // eslint-disable-next-line getter-return
+        get: () => {
+          if (value !== void 0) {
+            return value;
+          }
+          rune_outside_svelte(rune);
+        },
+        set: (v) => {
+          value = v;
+        }
+      });
+    }
+  };
+  throw_rune_error("$state");
+  throw_rune_error("$effect");
+  throw_rune_error("$derived");
+  throw_rune_error("$inspect");
+  throw_rune_error("$props");
+  throw_rune_error("$bindable");
+}
+
+// src/main.ts
 var import_obsidian4 = require("obsidian");
 
 // src/collection/config.ts
@@ -3033,20 +8308,20 @@ var DEFAULT_VALIDATION = "warn";
 var DEFAULT_STRICT = false;
 var SPEC_VERSION = "0.2.1";
 function getTypesFolder(config) {
-  var _a, _b;
-  return (_b = (_a = config.settings) == null ? void 0 : _a.types_folder) != null ? _b : DEFAULT_TYPES_FOLDER;
+  var _a5, _b3;
+  return (_b3 = (_a5 = config.settings) == null ? void 0 : _a5.types_folder) != null ? _b3 : DEFAULT_TYPES_FOLDER;
 }
 function getExplicitTypeKeys(config) {
-  var _a, _b;
-  return (_b = (_a = config.settings) == null ? void 0 : _a.explicit_type_keys) != null ? _b : DEFAULT_EXPLICIT_TYPE_KEYS;
+  var _a5, _b3;
+  return (_b3 = (_a5 = config.settings) == null ? void 0 : _a5.explicit_type_keys) != null ? _b3 : DEFAULT_EXPLICIT_TYPE_KEYS;
 }
 function getDefaultValidation(config) {
-  var _a, _b;
-  return (_b = (_a = config.settings) == null ? void 0 : _a.default_validation) != null ? _b : DEFAULT_VALIDATION;
+  var _a5, _b3;
+  return (_b3 = (_a5 = config.settings) == null ? void 0 : _a5.default_validation) != null ? _b3 : DEFAULT_VALIDATION;
 }
 function getDefaultStrict(config) {
-  var _a, _b;
-  return (_b = (_a = config.settings) == null ? void 0 : _a.default_strict) != null ? _b : DEFAULT_STRICT;
+  var _a5, _b3;
+  return (_b3 = (_a5 = config.settings) == null ? void 0 : _a5.default_strict) != null ? _b3 : DEFAULT_STRICT;
 }
 
 // src/collection/config.ts
@@ -3120,10 +8395,10 @@ async function loadTypes(vault, config) {
   const folder = getTypesFolder(config);
   const folderObj = vault.getFolderByPath(folder);
   if (!folderObj) return types;
-  for (const child of folderObj.children) {
-    if (!("extension" in child) || child.extension !== "md") continue;
+  for (const child2 of folderObj.children) {
+    if (!("extension" in child2) || child2.extension !== "md") continue;
     try {
-      const content = await vault.read(child);
+      const content = await vault.read(child2);
       const typeDef = parseTypeFile(content);
       if (typeDef) {
         types.set(typeDef.name.toLowerCase(), typeDef);
@@ -3162,7 +8437,7 @@ async function deleteType(vault, config, name) {
 // src/matching/matcher.ts
 var import_micromatch = __toESM(require_micromatch());
 function resolveInheritance(name, types, visited = /* @__PURE__ */ new Set()) {
-  var _a, _b;
+  var _a5, _b3;
   if (visited.has(name)) return null;
   visited.add(name);
   const def = types.get(name.toLowerCase());
@@ -3173,7 +8448,7 @@ function resolveInheritance(name, types, visited = /* @__PURE__ */ new Set()) {
   return {
     ...parent,
     ...def,
-    fields: { ...(_a = parent.fields) != null ? _a : {}, ...(_b = def.fields) != null ? _b : {} }
+    fields: { ...(_a5 = parent.fields) != null ? _a5 : {}, ...(_b3 = def.fields) != null ? _b3 : {} }
   };
 }
 function resolveType(name, types) {
@@ -3181,8 +8456,8 @@ function resolveType(name, types) {
 }
 function matchFileToTypes(filePath, frontmatter, types, config) {
   const explicitKeys = getExplicitTypeKeys(config);
-  for (const key of explicitKeys) {
-    const val = frontmatter[key];
+  for (const key2 of explicitKeys) {
+    const val = frontmatter[key2];
     if (val !== void 0 && val !== null) {
       const names = Array.isArray(val) ? val.map(String) : [String(val)];
       const resolved = [];
@@ -3483,11 +8758,11 @@ function validateObject(value, def) {
     };
   }
   if (def.fields) {
-    for (const [key, fieldDef] of Object.entries(def.fields)) {
-      const fieldValue = value[key];
+    for (const [key2, fieldDef] of Object.entries(def.fields)) {
+      const fieldValue = value[key2];
       const result = validateFieldValue(fieldValue, fieldDef);
       if (!result.valid) {
-        return { valid: false, message: `Field "${key}": ${result.message}` };
+        return { valid: false, message: `Field "${key2}": ${result.message}` };
       }
     }
   }
@@ -3555,10 +8830,10 @@ function validateFile(filePath, frontmatter, matchedTypes, config) {
   return issues;
 }
 function validateAgainstType(filePath, frontmatter, typeDef, config) {
-  var _a, _b, _c;
+  var _a5, _b3, _c2;
   const issues = [];
-  const fields = (_a = typeDef.fields) != null ? _a : {};
-  const strictMode = (_b = typeDef.strict) != null ? _b : getDefaultStrict(config);
+  const fields = (_a5 = typeDef.fields) != null ? _a5 : {};
+  const strictMode = (_b3 = typeDef.strict) != null ? _b3 : getDefaultStrict(config);
   for (const [fieldName, fieldDef] of Object.entries(fields)) {
     const value = frontmatter[fieldName];
     if ((value === void 0 || value === null) && fieldDef.required) {
@@ -3579,7 +8854,7 @@ function validateAgainstType(filePath, frontmatter, typeDef, config) {
           path: filePath,
           field: fieldName,
           code: "TYPE_MISMATCH",
-          message: (_c = result.message) != null ? _c : `Invalid value for field "${fieldName}"`,
+          message: (_c2 = result.message) != null ? _c2 : `Invalid value for field "${fieldName}"`,
           severity: "error",
           expected: result.expected,
           actual: result.actual,
@@ -3590,13 +8865,13 @@ function validateAgainstType(filePath, frontmatter, typeDef, config) {
   }
   if (strictMode !== false) {
     const knownFields = new Set(Object.keys(fields));
-    for (const key of Object.keys(frontmatter)) {
-      if (IMPLICIT_KEYS.has(key) || knownFields.has(key)) continue;
+    for (const key2 of Object.keys(frontmatter)) {
+      if (IMPLICIT_KEYS.has(key2) || knownFields.has(key2)) continue;
       issues.push({
         path: filePath,
-        field: key,
+        field: key2,
         code: "UNKNOWN_FIELD",
-        message: `Unknown field "${key}" (type: ${typeDef.name})`,
+        message: `Unknown field "${key2}" (type: ${typeDef.name})`,
         severity: strictMode === true ? "error" : "warning",
         type: typeDef.name
       });
@@ -3640,18 +8915,18 @@ var MdbaseSettingTab = class extends import_obsidian3.PluginSettingTab {
     const section = el.createDiv({ cls: "mdbase-settings-section" });
     section.createEl("h3", { text: "Collection Settings" });
     new import_obsidian3.Setting(section).setName("Name").setDesc("Human-readable collection title (optional).").addText(
-      (text) => {
-        var _a;
-        return text.setValue((_a = config.name) != null ? _a : "").onChange(async (value) => {
+      (text2) => {
+        var _a5;
+        return text2.setValue((_a5 = config.name) != null ? _a5 : "").onChange(async (value) => {
           config.name = value || void 0;
           await saveConfig(this.app.vault, config);
         });
       }
     );
     new import_obsidian3.Setting(section).setName("Description").setDesc("Short description of this collection (optional).").addText(
-      (text) => {
-        var _a;
-        return text.setValue((_a = config.description) != null ? _a : "").onChange(async (value) => {
+      (text2) => {
+        var _a5;
+        return text2.setValue((_a5 = config.description) != null ? _a5 : "").onChange(async (value) => {
           config.description = value || void 0;
           await saveConfig(this.app.vault, config);
         });
@@ -3659,10 +8934,10 @@ var MdbaseSettingTab = class extends import_obsidian3.PluginSettingTab {
     );
     new import_obsidian3.Setting(section).setName("Default validation").setDesc("How validation issues are handled globally.").addDropdown(
       (drop) => {
-        var _a, _b;
-        return drop.addOption("off", "Off").addOption("warn", "Warn").addOption("error", "Error").setValue((_b = (_a = config.settings) == null ? void 0 : _a.default_validation) != null ? _b : "warn").onChange(async (value) => {
-          var _a2;
-          (_a2 = config.settings) != null ? _a2 : config.settings = {};
+        var _a5, _b3;
+        return drop.addOption("off", "Off").addOption("warn", "Warn").addOption("error", "Error").setValue((_b3 = (_a5 = config.settings) == null ? void 0 : _a5.default_validation) != null ? _b3 : "warn").onChange(async (value) => {
+          var _a6;
+          (_a6 = config.settings) != null ? _a6 : config.settings = {};
           config.settings.default_validation = value;
           await saveConfig(this.app.vault, config);
         });
@@ -3670,21 +8945,21 @@ var MdbaseSettingTab = class extends import_obsidian3.PluginSettingTab {
     );
     new import_obsidian3.Setting(section).setName("Default strict mode").setDesc("How unknown frontmatter fields are handled.").addDropdown(
       (drop) => {
-        var _a, _b;
-        return drop.addOption("false", "Allow (no warning)").addOption("warn", "Warn").addOption("true", "Error").setValue(String((_b = (_a = config.settings) == null ? void 0 : _a.default_strict) != null ? _b : false)).onChange(async (value) => {
-          var _a2;
-          (_a2 = config.settings) != null ? _a2 : config.settings = {};
+        var _a5, _b3;
+        return drop.addOption("false", "Allow (no warning)").addOption("warn", "Warn").addOption("true", "Error").setValue(String((_b3 = (_a5 = config.settings) == null ? void 0 : _a5.default_strict) != null ? _b3 : false)).onChange(async (value) => {
+          var _a6;
+          (_a6 = config.settings) != null ? _a6 : config.settings = {};
           config.settings.default_strict = value === "true" ? true : value === "warn" ? "warn" : false;
           await saveConfig(this.app.vault, config);
         });
       }
     );
     new import_obsidian3.Setting(section).setName("Types folder").setDesc("Folder containing type definitions (default: _types).").addText(
-      (text) => {
-        var _a, _b;
-        return text.setPlaceholder("_types").setValue((_b = (_a = config.settings) == null ? void 0 : _a.types_folder) != null ? _b : "").onChange(async (value) => {
-          var _a2;
-          (_a2 = config.settings) != null ? _a2 : config.settings = {};
+      (text2) => {
+        var _a5, _b3;
+        return text2.setPlaceholder("_types").setValue((_b3 = (_a5 = config.settings) == null ? void 0 : _a5.types_folder) != null ? _b3 : "").onChange(async (value) => {
+          var _a6;
+          (_a6 = config.settings) != null ? _a6 : config.settings = {};
           config.settings.types_folder = value || void 0;
           await saveConfig(this.app.vault, config);
           await this.plugin.reload();
@@ -3720,17 +8995,17 @@ var MdbaseSettingTab = class extends import_obsidian3.PluginSettingTab {
     }
   }
   renderTypeItem(el, typeDef) {
-    var _a, _b, _c, _d;
+    var _a5, _b3, _c2, _d;
     const item = el.createDiv({ cls: "mdbase-type-item" });
     const header = item.createDiv({ cls: "mdbase-type-item-header" });
     const info = header.createDiv();
     info.createDiv({ cls: "mdbase-type-item-title", text: typeDef.name });
     const meta = [];
-    const fieldCount = Object.keys((_a = typeDef.fields) != null ? _a : {}).length;
+    const fieldCount = Object.keys((_a5 = typeDef.fields) != null ? _a5 : {}).length;
     meta.push(`${fieldCount} field${fieldCount !== 1 ? "s" : ""}`);
     if (typeDef.extends) meta.push(`extends: ${typeDef.extends}`);
-    if ((_b = typeDef.match) == null ? void 0 : _b.path_glob) meta.push(`glob: ${typeDef.match.path_glob}`);
-    if ((_d = (_c = typeDef.match) == null ? void 0 : _c.fields_present) == null ? void 0 : _d.length) {
+    if ((_b3 = typeDef.match) == null ? void 0 : _b3.path_glob) meta.push(`glob: ${typeDef.match.path_glob}`);
+    if ((_d = (_c2 = typeDef.match) == null ? void 0 : _c2.fields_present) == null ? void 0 : _d.length) {
       meta.push(`fields_present: ${typeDef.match.fields_present.join(", ")}`);
     }
     if (typeDef.description) {
@@ -3786,16 +9061,16 @@ var TypeEditorModal = class extends import_obsidian3.Modal {
     );
     new import_obsidian3.Setting(contentEl).setName("Description").addText(
       (t) => {
-        var _a;
-        return t.setValue((_a = this.draft.description) != null ? _a : "").onChange((v) => {
+        var _a5;
+        return t.setValue((_a5 = this.draft.description) != null ? _a5 : "").onChange((v) => {
           this.draft.description = v || void 0;
         });
       }
     );
     new import_obsidian3.Setting(contentEl).setName("Extends").setDesc("Parent type to inherit fields from.").addText(
       (t) => {
-        var _a;
-        return t.setValue((_a = this.draft.extends) != null ? _a : "").setPlaceholder("base-type").onChange((v) => {
+        var _a5;
+        return t.setValue((_a5 = this.draft.extends) != null ? _a5 : "").setPlaceholder("base-type").onChange((v) => {
           this.draft.extends = v || void 0;
         });
       }
@@ -3810,12 +9085,12 @@ var TypeEditorModal = class extends import_obsidian3.Modal {
     contentEl.createEl("h4", { text: "Match Rules (Level 2)" });
     new import_obsidian3.Setting(contentEl).setName("Path glob").setDesc('Auto-match files by path (e.g. "notes/*.md").').addText(
       (t) => {
-        var _a, _b;
-        return t.setValue((_b = (_a = this.draft.match) == null ? void 0 : _a.path_glob) != null ? _b : "").setPlaceholder("notes/*.md").onChange((v) => {
-          var _a2, _b2, _c;
-          (_b2 = (_a2 = this.draft).match) != null ? _b2 : _a2.match = {};
+        var _a5, _b3;
+        return t.setValue((_b3 = (_a5 = this.draft.match) == null ? void 0 : _a5.path_glob) != null ? _b3 : "").setPlaceholder("notes/*.md").onChange((v) => {
+          var _a6, _b4, _c2;
+          (_b4 = (_a6 = this.draft).match) != null ? _b4 : _a6.match = {};
           this.draft.match.path_glob = v || void 0;
-          if (!this.draft.match.path_glob && !((_c = this.draft.match.fields_present) == null ? void 0 : _c.length)) {
+          if (!this.draft.match.path_glob && !((_c2 = this.draft.match.fields_present) == null ? void 0 : _c2.length)) {
             this.draft.match = void 0;
           }
         });
@@ -3823,13 +9098,13 @@ var TypeEditorModal = class extends import_obsidian3.Modal {
     );
     new import_obsidian3.Setting(contentEl).setName("Fields present").setDesc("Auto-match if these fields exist (comma-separated).").addText(
       (t) => {
-        var _a, _b;
-        return t.setValue(((_b = (_a = this.draft.match) == null ? void 0 : _a.fields_present) != null ? _b : []).join(", ")).setPlaceholder("due_date, status").onChange((v) => {
-          var _a2, _b2, _c;
+        var _a5, _b3;
+        return t.setValue(((_b3 = (_a5 = this.draft.match) == null ? void 0 : _a5.fields_present) != null ? _b3 : []).join(", ")).setPlaceholder("due_date, status").onChange((v) => {
+          var _a6, _b4, _c2;
           const fields = v.split(",").map((s) => s.trim()).filter(Boolean);
-          (_b2 = (_a2 = this.draft).match) != null ? _b2 : _a2.match = {};
+          (_b4 = (_a6 = this.draft).match) != null ? _b4 : _a6.match = {};
           this.draft.match.fields_present = fields.length ? fields : void 0;
-          if (!this.draft.match.path_glob && !((_c = this.draft.match.fields_present) == null ? void 0 : _c.length)) {
+          if (!this.draft.match.path_glob && !((_c2 = this.draft.match.fields_present) == null ? void 0 : _c2.length)) {
             this.draft.match = void 0;
           }
         });
@@ -3840,8 +9115,8 @@ var TypeEditorModal = class extends import_obsidian3.Modal {
     this.renderFieldList(fieldList);
     new import_obsidian3.Setting(contentEl).addButton(
       (btn) => btn.setButtonText("Add Field").onClick(() => {
-        var _a, _b;
-        (_b = (_a = this.draft).fields) != null ? _b : _a.fields = {};
+        var _a5, _b3;
+        (_b3 = (_a5 = this.draft).fields) != null ? _b3 : _a5.fields = {};
         const modal = new FieldEditorModal(
           this.app,
           null,
@@ -3875,9 +9150,9 @@ var TypeEditorModal = class extends import_obsidian3.Modal {
     });
   }
   renderFieldList(el) {
-    var _a;
+    var _a5;
     el.empty();
-    const fields = (_a = this.draft.fields) != null ? _a : {};
+    const fields = (_a5 = this.draft.fields) != null ? _a5 : {};
     if (Object.keys(fields).length === 0) {
       el.createDiv({ cls: "mdbase-empty-state", text: "No fields defined." });
       return;
@@ -3951,16 +9226,16 @@ var FieldEditorModal = class extends import_obsidian3.Modal {
     });
     new import_obsidian3.Setting(contentEl).setName("Required").addToggle(
       (t) => {
-        var _a;
-        return t.setValue((_a = this.draft.required) != null ? _a : false).onChange((v) => {
+        var _a5;
+        return t.setValue((_a5 = this.draft.required) != null ? _a5 : false).onChange((v) => {
           this.draft.required = v || void 0;
         });
       }
     );
     new import_obsidian3.Setting(contentEl).setName("Description").addText(
       (t) => {
-        var _a;
-        return t.setValue((_a = this.draft.description) != null ? _a : "").onChange((v) => {
+        var _a5;
+        return t.setValue((_a5 = this.draft.description) != null ? _a5 : "").onChange((v) => {
           this.draft.description = v || void 0;
         });
       }
@@ -3987,24 +9262,24 @@ var FieldEditorModal = class extends import_obsidian3.Modal {
     if (type === "string") {
       new import_obsidian3.Setting(el).setName("Min length").addText(
         (t) => {
-          var _a;
-          return t.setValue(String((_a = this.draft.min_length) != null ? _a : "")).setPlaceholder("0").onChange((v) => {
+          var _a5;
+          return t.setValue(String((_a5 = this.draft.min_length) != null ? _a5 : "")).setPlaceholder("0").onChange((v) => {
             this.draft.min_length = v ? parseInt(v) : void 0;
           });
         }
       );
       new import_obsidian3.Setting(el).setName("Max length").addText(
         (t) => {
-          var _a;
-          return t.setValue(String((_a = this.draft.max_length) != null ? _a : "")).onChange((v) => {
+          var _a5;
+          return t.setValue(String((_a5 = this.draft.max_length) != null ? _a5 : "")).onChange((v) => {
             this.draft.max_length = v ? parseInt(v) : void 0;
           });
         }
       );
       new import_obsidian3.Setting(el).setName("Pattern (regex)").addText(
         (t) => {
-          var _a;
-          return t.setValue((_a = this.draft.pattern) != null ? _a : "").onChange((v) => {
+          var _a5;
+          return t.setValue((_a5 = this.draft.pattern) != null ? _a5 : "").onChange((v) => {
             this.draft.pattern = v || void 0;
           });
         }
@@ -4013,16 +9288,16 @@ var FieldEditorModal = class extends import_obsidian3.Modal {
     if (type === "integer" || type === "number") {
       new import_obsidian3.Setting(el).setName("Min").addText(
         (t) => {
-          var _a;
-          return t.setValue(String((_a = this.draft.min) != null ? _a : "")).onChange((v) => {
+          var _a5;
+          return t.setValue(String((_a5 = this.draft.min) != null ? _a5 : "")).onChange((v) => {
             this.draft.min = v ? Number(v) : void 0;
           });
         }
       );
       new import_obsidian3.Setting(el).setName("Max").addText(
         (t) => {
-          var _a;
-          return t.setValue(String((_a = this.draft.max) != null ? _a : "")).onChange((v) => {
+          var _a5;
+          return t.setValue(String((_a5 = this.draft.max) != null ? _a5 : "")).onChange((v) => {
             this.draft.max = v ? Number(v) : void 0;
           });
         }
@@ -4031,8 +9306,8 @@ var FieldEditorModal = class extends import_obsidian3.Modal {
     if (type === "enum") {
       new import_obsidian3.Setting(el).setName("Values").setDesc("Comma-separated list of allowed values.").addText(
         (t) => {
-          var _a;
-          return t.setValue(((_a = this.draft.values) != null ? _a : []).join(", ")).onChange((v) => {
+          var _a5;
+          return t.setValue(((_a5 = this.draft.values) != null ? _a5 : []).join(", ")).onChange((v) => {
             this.draft.values = v.split(",").map((s) => s.trim()).filter(Boolean);
           });
         }
@@ -4040,19 +9315,19 @@ var FieldEditorModal = class extends import_obsidian3.Modal {
     }
     if (type === "list") {
       new import_obsidian3.Setting(el).setName("Element type").addDropdown((d) => {
-        var _a;
+        var _a5;
         const elementTypes = FIELD_TYPES.filter(
           (f) => f !== "list" && f !== "object"
         );
         for (const ft of elementTypes) d.addOption(ft, ft);
-        return d.setValue((_a = this.draft.element_type) != null ? _a : "string").onChange((v) => {
+        return d.setValue((_a5 = this.draft.element_type) != null ? _a5 : "string").onChange((v) => {
           this.draft.element_type = v;
         });
       });
       new import_obsidian3.Setting(el).setName("Unique elements").addToggle(
         (t) => {
-          var _a;
-          return t.setValue((_a = this.draft.unique_elements) != null ? _a : false).onChange((v) => {
+          var _a5;
+          return t.setValue((_a5 = this.draft.unique_elements) != null ? _a5 : false).onChange((v) => {
             this.draft.unique_elements = v || void 0;
           });
         }
@@ -4063,6 +9338,93 @@ var FieldEditorModal = class extends import_obsidian3.Modal {
     this.contentEl.empty();
   }
 };
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/version.js
+var PUBLIC_VERSION = "5";
+
+// ../../../node_modules/.pnpm/svelte@5.55.4/node_modules/svelte/src/internal/disclose-version.js
+var _a4, _b2, _c;
+if (typeof window !== "undefined") {
+  ((_c = (_b2 = (_a4 = window.__svelte) != null ? _a4 : window.__svelte = {}).v) != null ? _c : _b2.v = /* @__PURE__ */ new Set()).add(PUBLIC_VERSION);
+}
+
+// src/ui/FileIssueItem.svelte
+var root_1 = from_html(`<div class="mdbase-issue-type"> </div>`);
+var root = from_html(`<div><div class="mdbase-issue-field"> </div> <div class="mdbase-issue-message"> </div> <!></div>`);
+function FileIssueItem($$anchor, $$props) {
+  push($$props, true);
+  const meta = user_derived(() => {
+    var _a5;
+    return [
+      $$props.issue.type ? `type: ${$$props.issue.type}` : null,
+      (_a5 = $$props.issue.code) != null ? _a5 : null
+    ].filter(Boolean).join(" \xB7 ");
+  });
+  var div = root();
+  var div_1 = child(div);
+  var text2 = child(div_1, true);
+  reset(div_1);
+  var div_2 = sibling(div_1, 2);
+  var text_1 = child(div_2, true);
+  reset(div_2);
+  var node = sibling(div_2, 2);
+  {
+    var consequent = ($$anchor2) => {
+      var div_3 = root_1();
+      var text_2 = child(div_3, true);
+      reset(div_3);
+      template_effect(() => set_text(text_2, get2(meta)));
+      append($$anchor2, div_3);
+    };
+    if_block(node, ($$render) => {
+      if (get2(meta)) $$render(consequent);
+    });
+  }
+  reset(div);
+  template_effect(() => {
+    var _a5;
+    set_class(div, 1, `mdbase-issue-item ${(_a5 = $$props.issue.severity) != null ? _a5 : ""}`);
+    set_text(text2, $$props.issue.field);
+    set_text(text_1, $$props.issue.message);
+  });
+  append($$anchor, div);
+  pop();
+}
+
+// src/ui/ValidationModal.svelte
+var root_12 = from_html(`<p class="mdbase-status-ok">No issues found. \u2713</p>`);
+var root_2 = from_html(`<div class="mdbase-issue-list"></div>`);
+var root2 = from_html(`<div class="mdbase-validation-modal"><!></div>`);
+function ValidationModal($$anchor, $$props) {
+  push($$props, true);
+  var div = root2();
+  var node = child(div);
+  {
+    var consequent = ($$anchor2) => {
+      var p = root_12();
+      append($$anchor2, p);
+    };
+    var alternate = ($$anchor2) => {
+      var div_1 = root_2();
+      each(div_1, 21, () => $$props.issues, (issue) => issue.field + issue.code, ($$anchor3, issue) => {
+        FileIssueItem($$anchor3, {
+          get issue() {
+            return get2(issue);
+          }
+        });
+      });
+      reset(div_1);
+      append($$anchor2, div_1);
+    };
+    if_block(node, ($$render) => {
+      if ($$props.issues.length === 0) $$render(consequent);
+      else $$render(alternate, -1);
+    });
+  }
+  reset(div);
+  append($$anchor, div);
+  pop();
+}
 
 // src/main.ts
 var MdbasePlugin = class extends import_obsidian4.Plugin {
@@ -4129,12 +9491,12 @@ var MdbasePlugin = class extends import_obsidian4.Plugin {
     }
   }
   async validateAndDisplay(file) {
-    var _a, _b;
+    var _a5, _b3;
     if (!this.config) {
       this.statusBarItem.setText("mdbase: no collection");
       return;
     }
-    const fm = (_b = (_a = this.app.metadataCache.getFileCache(file)) == null ? void 0 : _a.frontmatter) != null ? _b : {};
+    const fm = (_b3 = (_a5 = this.app.metadataCache.getFileCache(file)) == null ? void 0 : _a5.frontmatter) != null ? _b3 : {};
     const matched = matchFileToTypes(file.path, fm, this.types, this.config);
     const fileIssues = validateFile(file.path, fm, matched, this.config);
     this.issues.set(file.path, fileIssues);
@@ -4170,18 +9532,18 @@ var MdbasePlugin = class extends import_obsidian4.Plugin {
     }
   }
   validateCurrentFile() {
-    var _a;
+    var _a5;
     const file = this.app.workspace.getActiveFile();
     if (!file) {
       new import_obsidian4.Notice("No active file.");
       return;
     }
-    const fileIssues = (_a = this.issues.get(file.path)) != null ? _a : [];
-    const modal = new ValidationModal(this.app, file, fileIssues);
+    const fileIssues = (_a5 = this.issues.get(file.path)) != null ? _a5 : [];
+    const modal = new ValidationModal2(this.app, file, fileIssues);
     modal.open();
   }
   async validateAllFiles() {
-    var _a, _b;
+    var _a5, _b3;
     if (!this.config) {
       new import_obsidian4.Notice("No mdbase collection found.");
       return;
@@ -4191,7 +9553,7 @@ var MdbasePlugin = class extends import_obsidian4.Plugin {
     let totalWarnings = 0;
     this.issues.clear();
     for (const file of files) {
-      const fm = (_b = (_a = this.app.metadataCache.getFileCache(file)) == null ? void 0 : _a.frontmatter) != null ? _b : {};
+      const fm = (_b3 = (_a5 = this.app.metadataCache.getFileCache(file)) == null ? void 0 : _a5.frontmatter) != null ? _b3 : {};
       const matched = matchFileToTypes(file.path, fm, this.types, this.config);
       const fileIssues = validateFile(file.path, fm, matched, this.config);
       this.issues.set(file.path, fileIssues);
@@ -4205,38 +9567,22 @@ var MdbasePlugin = class extends import_obsidian4.Plugin {
     );
   }
 };
-var ValidationModal = class extends import_obsidian4.Modal {
+var ValidationModal2 = class extends import_obsidian4.Modal {
   constructor(app, file, issues) {
     super(app);
+    this.component = null;
     this.file = file;
     this.fileIssues = issues;
   }
   onOpen() {
     this.titleEl.setText(`Validation: ${this.file.name}`);
-    const { contentEl } = this;
-    contentEl.addClass("mdbase-validation-modal");
-    if (this.fileIssues.length === 0) {
-      contentEl.createEl("p", {
-        text: "No issues found. \u2713",
-        cls: "mdbase-status-ok"
-      });
-      return;
-    }
-    const list = contentEl.createDiv({ cls: "mdbase-issue-list" });
-    for (const issue of this.fileIssues) {
-      const item = list.createDiv({
-        cls: `mdbase-issue-item ${issue.severity}`
-      });
-      item.createDiv({ cls: "mdbase-issue-field", text: issue.field });
-      item.createDiv({ cls: "mdbase-issue-message", text: issue.message });
-      const meta = [];
-      if (issue.type) meta.push(`type: ${issue.type}`);
-      if (issue.code) meta.push(issue.code);
-      if (meta.length)
-        item.createDiv({ cls: "mdbase-issue-type", text: meta.join(" \xB7 ") });
-    }
+    this.component = mount(ValidationModal, {
+      target: this.contentEl,
+      props: { issues: this.fileIssues }
+    });
   }
   onClose() {
+    if (this.component) unmount(this.component);
     this.contentEl.empty();
   }
 };

--- a/main.js
+++ b/main.js
@@ -4073,10 +4073,6 @@ var MdbasePlugin = class extends import_obsidian4.Plugin {
     this.issues = /* @__PURE__ */ new Map();
   }
   async onload() {
-    this.config = await loadConfig(this.app.vault);
-    if (this.config) {
-      this.types = await loadTypes(this.app.vault, this.config);
-    }
     this.statusBarItem = this.addStatusBarItem();
     this.statusBarItem.setText("mdbase");
     this.addSettingTab(new MdbaseSettingTab(this.app, this));
@@ -4111,15 +4107,21 @@ var MdbasePlugin = class extends import_obsidian4.Plugin {
         }
       })
     );
+    this.app.workspace.onLayoutReady(async () => {
+      await this.loadConfig();
+    });
   }
   async initializeCollection() {
     this.config = await createDefaultConfig(this.app.vault);
     this.types = /* @__PURE__ */ new Map();
     new import_obsidian4.Notice("Collection initialized! mdbase.yaml created at vault root.");
   }
-  async reload() {
+  async loadConfig() {
     this.config = await loadConfig(this.app.vault);
     this.types = this.config ? await loadTypes(this.app.vault, this.config) : /* @__PURE__ */ new Map();
+  }
+  async reload() {
+    await this.loadConfig();
     this.issues.clear();
     const activeFile = this.app.workspace.getActiveFile();
     if (activeFile) {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
     "@types/node": "^22.0.0",
     "builtin-modules": "^4.0.0",
     "esbuild": "^0.21.5",
+    "esbuild-svelte": "^0.9.4",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "obsidian": "^1.4.11",
     "prettier": "^3.8.3",
+    "svelte": "^5.55.4",
     "tslib": "^2.6.3",
     "typescript": "^5.4.5"
   },

--- a/src/collection/config.ts
+++ b/src/collection/config.ts
@@ -3,7 +3,7 @@ import { parseYaml, stringifyYaml } from "obsidian";
 import type { MdbaseConfig } from "../types.ts";
 import { SPEC_VERSION } from "../types.ts";
 
-const CONFIG_FILENAME = "mdbase.yaml";
+export const CONFIG_FILENAME = "mdbase.yaml";
 
 export async function loadConfig(vault: Vault): Promise<MdbaseConfig | null> {
   const file = vault.getFileByPath(CONFIG_FILENAME);

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,11 +17,6 @@ export default class MdbasePlugin extends Plugin {
   private statusBarItem!: HTMLElement;
 
   async onload(): Promise<void> {
-    this.config = await loadConfig(this.app.vault);
-    if (this.config) {
-      this.types = await loadTypes(this.app.vault, this.config);
-    }
-
     this.statusBarItem = this.addStatusBarItem();
     this.statusBarItem.setText("mdbase");
 
@@ -62,6 +57,10 @@ export default class MdbasePlugin extends Plugin {
         }
       }),
     );
+
+    this.app.workspace.onLayoutReady(async () => {
+      await this.loadConfig();
+    });
   }
 
   async initializeCollection(): Promise<void> {
@@ -70,11 +69,16 @@ export default class MdbasePlugin extends Plugin {
     new Notice("Collection initialized! mdbase.yaml created at vault root.");
   }
 
-  async reload(): Promise<void> {
+  async loadConfig(): Promise<void> {
     this.config = await loadConfig(this.app.vault);
     this.types = this.config
       ? await loadTypes(this.app.vault, this.config)
       : new Map();
+  }
+
+  async reload(): Promise<void> {
+    await this.loadConfig();
+
     this.issues.clear();
     const activeFile = this.app.workspace.getActiveFile();
     if (activeFile) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { App, Modal, Notice, Plugin, TFile } from "obsidian";
 import type { MdbaseConfig, TypeDefinition, ValidationIssue } from "./types.ts";
-import { createDefaultConfig, loadConfig } from "./collection/config.ts";
+import { CONFIG_FILENAME, createDefaultConfig, loadConfig } from "./collection/config.ts";
 import { loadTypes } from "./collection/typeLoader.ts";
 import { matchFileToTypes } from "./matching/matcher.ts";
 import { validateFile } from "./validation/validator.ts";
@@ -49,6 +49,14 @@ export default class MdbasePlugin extends Plugin {
           this.validateAndDisplay(file);
         }
       }),
+    );
+
+    this.registerEvent(
+      this.app.vault.on("modify", (file) => {
+        if (file.path === CONFIG_FILENAME) {
+          this.reload();
+        }
+      })
     );
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { mount, unmount } from "svelte";
 import { App, Modal, Notice, Plugin, TFile } from "obsidian";
 import type { MdbaseConfig, TypeDefinition, ValidationIssue } from "./types.ts";
 import {
@@ -9,6 +10,7 @@ import { loadTypes } from "./collection/typeLoader.ts";
 import { matchFileToTypes } from "./matching/matcher.ts";
 import { validateFile } from "./validation/validator.ts";
 import { MdbaseSettingTab } from "./settings/SettingsTab.ts";
+import ValidationModalComponent from "./ui/ValidationModal.svelte";
 
 export default class MdbasePlugin extends Plugin {
   config: MdbaseConfig | null = null;
@@ -175,6 +177,7 @@ export default class MdbasePlugin extends Plugin {
 class ValidationModal extends Modal {
   file: TFile;
   fileIssues: ValidationIssue[];
+  private component: ReturnType<typeof mount> | null = null;
 
   constructor(app: App, file: TFile, issues: ValidationIssue[]) {
     super(app);
@@ -184,33 +187,14 @@ class ValidationModal extends Modal {
 
   onOpen(): void {
     this.titleEl.setText(`Validation: ${this.file.name}`);
-    const { contentEl } = this;
-    contentEl.addClass("mdbase-validation-modal");
-
-    if (this.fileIssues.length === 0) {
-      contentEl.createEl("p", {
-        text: "No issues found. ✓",
-        cls: "mdbase-status-ok",
-      });
-      return;
-    }
-
-    const list = contentEl.createDiv({ cls: "mdbase-issue-list" });
-    for (const issue of this.fileIssues) {
-      const item = list.createDiv({
-        cls: `mdbase-issue-item ${issue.severity}`,
-      });
-      item.createDiv({ cls: "mdbase-issue-field", text: issue.field });
-      item.createDiv({ cls: "mdbase-issue-message", text: issue.message });
-      const meta: string[] = [];
-      if (issue.type) meta.push(`type: ${issue.type}`);
-      if (issue.code) meta.push(issue.code);
-      if (meta.length)
-        item.createDiv({ cls: "mdbase-issue-type", text: meta.join(" · ") });
-    }
+    this.component = mount(ValidationModalComponent, {
+      target: this.contentEl,
+      props: { issues: this.fileIssues },
+    });
   }
 
   onClose(): void {
+    if (this.component) unmount(this.component);
     this.contentEl.empty();
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
 import { App, Modal, Notice, Plugin, TFile } from "obsidian";
 import type { MdbaseConfig, TypeDefinition, ValidationIssue } from "./types.ts";
-import { CONFIG_FILENAME, createDefaultConfig, loadConfig } from "./collection/config.ts";
+import {
+  CONFIG_FILENAME,
+  createDefaultConfig,
+  loadConfig,
+} from "./collection/config.ts";
 import { loadTypes } from "./collection/typeLoader.ts";
 import { matchFileToTypes } from "./matching/matcher.ts";
 import { validateFile } from "./validation/validator.ts";
@@ -56,7 +60,7 @@ export default class MdbasePlugin extends Plugin {
         if (file.path === CONFIG_FILENAME) {
           this.reload();
         }
-      })
+      }),
     );
   }
 

--- a/src/ui/FileIssueItem.svelte
+++ b/src/ui/FileIssueItem.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { ValidationIssue } from "../types.ts";
+
+  const { issue }: { issue: ValidationIssue } = $props();
+
+  const meta = $derived(
+    [issue.type ? `type: ${issue.type}` : null, issue.code ?? null]
+      .filter(Boolean)
+      .join(" · "),
+  );
+</script>
+
+<div class="mdbase-issue-item {issue.severity}">
+  <div class="mdbase-issue-field">{issue.field}</div>
+  <div class="mdbase-issue-message">{issue.message}</div>
+  {#if meta}
+    <div class="mdbase-issue-type">{meta}</div>
+  {/if}
+</div>

--- a/src/ui/ValidationModal.svelte
+++ b/src/ui/ValidationModal.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { ValidationIssue } from "../types.ts";
+  import FileIssueItem from "./FileIssueItem.svelte";
+
+  const { issues }: { issues: ValidationIssue[] } = $props();
+</script>
+
+<div class="mdbase-validation-modal">
+  {#if issues.length === 0}
+    <p class="mdbase-status-ok">No issues found. ✓</p>
+  {:else}
+    <div class="mdbase-issue-list">
+      {#each issues as issue (issue.field + issue.code)}
+        <FileIssueItem {issue} />
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "verbatimModuleSyntax": true,
     "lib": ["ES2018", "DOM"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.svelte"]
 }


### PR DESCRIPTION
## Summary

- Adds `svelte` and `esbuild-svelte` as dev dependencies; configures the esbuild plugin so `.svelte` files compile into the bundle
- Replaces the manual DOM manipulation in `ValidationModal` with two Svelte 5 components under `src/ui/`:
  - **`ValidationModal.svelte`** — modal content shell, handles the empty/has-issues branches
  - **`FileIssueItem.svelte`** — renders a single validation issue row (field, message, type/code meta)
- The `ValidationModal` class in `main.ts` now calls `mount()` on open and `unmount()` on close; all CSS class names are unchanged so existing styles still apply

## Test plan

- [ ] Open a file that matches a type and has validation errors → `Validate current file` should open the modal with issue rows
- [ ] Open a file with no issues → modal should show "No issues found. ✓"
- [ ] Close and re-open the modal — no duplicate content or memory leaks
- [ ] Run `pnpm build` and confirm it exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)